### PR TITLE
Add placeholder OAuth client id resource

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="app_name">CDS</string>
     <string name="sign_in_with_google">Sign in with Google</string>
     <string name="welcome_message">Welcome, %1$s!</string>
+    <!-- Placeholder client ID used for development builds -->
+    <string name="default_web_client_id">YOUR_WEB_CLIENT_ID</string>
 </resources>


### PR DESCRIPTION
## Summary
- add placeholder default_web_client_id string for Google Sign-In

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e50a5d8f083298a793102d81f5dfa