### PR TITLE
Add Google and email sign-in with persistent sessions

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.concepts_and_quizzes.cds.auth.LoginScreen
+import com.concepts_and_quizzes.cds.auth.RegisterScreen
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -27,6 +29,8 @@ class MainActivity : ComponentActivity() {
     private lateinit var googleSignInClient: GoogleSignInClient
     private val auth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
     private val currentUser = mutableStateOf<FirebaseUser?>(null)
+    private val showRegister = mutableStateOf(false)
+    private val prefs by lazy { getSharedPreferences("auth", MODE_PRIVATE) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,12 +52,56 @@ class MainActivity : ComponentActivity() {
             }
         }
 
+        if (currentUser.value == null) {
+            val email = prefs.getString("email", null)
+            val password = prefs.getString("password", null)
+            if (email != null && password != null) {
+                auth.signInWithEmailAndPassword(email, password)
+                    .addOnCompleteListener { task ->
+                        if (task.isSuccessful) currentUser.value = auth.currentUser
+                    }
+            } else {
+                googleSignInClient.silentSignIn().addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        val account = task.result
+                        firebaseAuthWithGoogle(account.idToken!!)
+                    }
+                }
+            }
+        }
+
         setContent {
             val user = currentUser.value
             if (user == null) {
-                SignInScreen(onGoogleSignIn = { signInLauncher.launch(googleSignInClient.signInIntent) })
+                if (showRegister.value) {
+                    RegisterScreen(
+                        onRegistrationSuccess = { email, password ->
+                            prefs.edit().putString("email", email).putString("password", password).apply()
+                            currentUser.value = auth.currentUser
+                            showRegister.value = false
+                        },
+                        onBackToLogin = { showRegister.value = false }
+                    )
+                } else {
+                    LoginScreen(
+                        onNavigateToRegister = { showRegister.value = true },
+                        onLoginSuccess = { email, password ->
+                            prefs.edit().putString("email", email).putString("password", password).apply()
+                            currentUser.value = auth.currentUser
+                        },
+                        onGoogleSignIn = { signInLauncher.launch(googleSignInClient.signInIntent) }
+                    )
+                }
             } else {
-                DashboardScreen(user.displayName ?: "")
+                DashboardScreen(
+                    user.displayName ?: "",
+                    onSignOut = {
+                        auth.signOut()
+                        googleSignInClient.signOut()
+                        prefs.edit().clear().apply()
+                        currentUser.value = null
+                    }
+                )
             }
         }
     }
@@ -69,7 +117,7 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun SignInScreen(onGoogleSignIn: () -> Unit) {
+fun DashboardScreen(name: String, onSignOut: () -> Unit) {
     Scaffold { padding ->
         Column(
             modifier = Modifier
@@ -79,25 +127,14 @@ fun SignInScreen(onGoogleSignIn: () -> Unit) {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(text = stringResource(id = R.string.app_name), style = MaterialTheme.typography.headlineMedium)
+            Text(
+                text = stringResource(id = R.string.welcome_message, name),
+                style = MaterialTheme.typography.headlineMedium
+            )
             Spacer(modifier = Modifier.height(24.dp))
-            Button(onClick = onGoogleSignIn, modifier = Modifier.fillMaxWidth()) {
-                Text(text = stringResource(id = R.string.sign_in_with_google))
+            Button(onClick = onSignOut) {
+                Text(text = stringResource(id = R.string.sign_out))
             }
-        }
-    }
-}
-
-@Composable
-fun DashboardScreen(name: String) {
-    Scaffold { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(text = stringResource(id = R.string.welcome_message, name), style = MaterialTheme.typography.headlineMedium)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">CDS</string>
     <string name="sign_in_with_google">Sign in with Google</string>
     <string name="welcome_message">Welcome, %1$s!</string>
+    <string name="sign_out">Sign out</string>
     <!-- Placeholder client ID used for development builds -->
     <string name="default_web_client_id">YOUR_WEB_CLIENT_ID</string>
 </resources>


### PR DESCRIPTION
## Summary
- show Google Sign-In with an email login alternative
- allow email registration with user name and store credentials
- persist sessions across app restarts and add dashboard sign-out

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e536e5bb083299687116342b137c8