### PR TITLE
fix: remove unavailable firebase auth ktx

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,10 +59,7 @@ dependencies {
     implementation(libs.firebase.auth)            // <-- version is inherited from the BOM
     implementation(libs.credentials)
     implementation(libs.credentials.playservices)
-    implementation(libs.credentials)
-    implementation(libs.credentials.playservices)
     implementation("androidx.compose.material:material-icons-extended")
-    implementation(libs.firebase.auth.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ activityCompose = "1.10.1"
 composeBom = "2025.07.00"
 credentials = "1.5.0"
 firebase-bom = "34.0.0"
-firebaseAuthKtx = "24.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -32,7 +31,6 @@ credentials-playservices = { module = "androidx.credentials:credentials-play-ser
 
 firebase-bom   = { group = "com.google.firebase", name = "firebase-bom",  version.ref = "firebase-bom" }
 firebase-auth  = { group = "com.google.firebase", name = "firebase-auth-ktx" }
-firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary
- remove direct dependency on `firebase-auth-ktx` with invalid 24.0.0 version
- rely on Firebase BOM for auth dependency

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688edbf2db6c83299b3b023c4a3ee801