### PR TITLE
Add Google Identity dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation(libs.firebase.auth)            // <-- version is inherited from the BOM
     implementation(libs.credentials)
     implementation(libs.credentials.playservices)
+    implementation(libs.googleid)
     implementation("androidx.compose.material:material-icons-extended")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ composeBom = "2025.07.00"
 credentials = "1.5.0"
 firebase-bom = "34.0.0"
 firebase-auth = "23.2.1"
+googleid = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +30,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 credentials              = { module = "androidx.credentials:credentials",                     version.ref = "credentials" }
 credentials-playservices = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
+googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
 
 firebase-bom   = { group = "com.google.firebase", name = "firebase-bom",  version.ref = "firebase-bom" }
 firebase-auth  = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebase-auth" }


### PR DESCRIPTION
## Summary
- add Google Identity Services library to gradle catalog
- depend on new library for credential-based sign-in

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ee302d58c8329b9dc4e8141d3ee14