### PR TITLE
refactor auth flow

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/auth/AuthRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/auth/AuthRepository.kt
@@ -1,0 +1,65 @@
+package com.concepts_and_quizzes.cds.auth
+
+import android.content.Context
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialException
+import com.concepts_and_quizzes.cds.R
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GoogleAuthProvider
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class AuthRepository(private val context: Context) {
+    private val credentialManager = CredentialManager.create(context)
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+    private val googleRequest: GetCredentialRequest by lazy {
+        GetCredentialRequest.Builder()
+            .addCredentialOption(
+                GetGoogleIdOption.Builder()
+                    .setServerClientId(context.getString(R.string.default_web_client_id))
+                    .setFilterByAuthorizedAccounts(true)
+                    .build()
+            )
+            .build()
+    }
+
+    val currentUser: FirebaseUser? get() = auth.currentUser
+
+    suspend fun startGoogleSignIn(): FirebaseUser? {
+        return try {
+            val result = credentialManager.getCredential(context, googleRequest)
+            (result.credential as? GoogleIdTokenCredential)?.let { firebaseAuthWithGoogle(it.idToken) }
+        } catch (e: GetCredentialException) {
+            null
+        }
+    }
+
+    suspend fun trySilentSignIn(): FirebaseUser? {
+        return try {
+            val result = credentialManager.getCredential(context, googleRequest)
+            (result.credential as? GoogleIdTokenCredential)?.let { firebaseAuthWithGoogle(it.idToken) }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private suspend fun firebaseAuthWithGoogle(idToken: String): FirebaseUser? =
+        suspendCancellableCoroutine { cont ->
+            val credential = GoogleAuthProvider.getCredential(idToken, null)
+            auth.signInWithCredential(credential)
+                .addOnSuccessListener { cont.resume(auth.currentUser) }
+                .addOnFailureListener { cont.resumeWithException(it) }
+        }
+
+    suspend fun signOut() {
+        auth.signOut()
+        credentialManager.clearCredentialState(ClearCredentialStateRequest())
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/auth/AuthScreens.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/auth/AuthScreens.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -20,7 +21,8 @@ fun LoginScreen(
     auth: FirebaseAuth = FirebaseAuth.getInstance(),
     onNavigateToRegister: () -> Unit,
     onLoginSuccess: (String, String) -> Unit,
-    onGoogleSignIn: () -> Unit
+    onGoogleSignIn: () -> Unit,
+    isSigningIn: Boolean = false
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -30,15 +32,20 @@ fun LoginScreen(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp),
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Button(
-            onClick = onGoogleSignIn,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 16.dp)
-        ) {
-            Text(stringResource(id = R.string.sign_in_with_google))
+        if (isSigningIn) {
+            CircularProgressIndicator(modifier = Modifier.padding(bottom = 16.dp))
+        } else {
+            Button(
+                onClick = onGoogleSignIn,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            ) {
+                Text(stringResource(id = R.string.sign_in_with_google))
+            }
         }
         OutlinedTextField(
             value = email,


### PR DESCRIPTION
## Summary
- move credential and firebase interactions into `AuthRepository`
- show progress indicator during Google sign-in and handle failures

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ee6e528808329aab17a16fc1b457e