### PR TITLE
Refactor auth flow with ViewModel and secure storage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.credentials.playservices)
     implementation(libs.googleid)
     implementation("androidx.compose.material:material-icons-extended")
+    implementation(libs.androidx.security.crypto)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/auth/AuthViewModel.kt
@@ -1,0 +1,166 @@
+package com.concepts_and_quizzes.cds.auth
+
+import android.content.Context
+import android.util.Patterns
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseUser
+import kotlinx.coroutines.launch
+
+// State holders
+data class LoginUiState(
+    val email: String = "",
+    val password: String = "",
+    val emailError: String? = null,
+    val passwordError: String? = null,
+    val authError: String? = null,
+    val isLoading: Boolean = false
+)
+
+data class RegisterUiState(
+    val name: String = "",
+    val email: String = "",
+    val password: String = "",
+    val nameError: String? = null,
+    val emailError: String? = null,
+    val passwordError: String? = null,
+    val authError: String? = null,
+    val isLoading: Boolean = false
+)
+
+class AuthViewModel(private val repository: AuthRepository) : ViewModel() {
+    var loginState by androidx.compose.runtime.mutableStateOf(LoginUiState())
+        private set
+    var registerState by androidx.compose.runtime.mutableStateOf(RegisterUiState())
+        private set
+    var currentUser by androidx.compose.runtime.mutableStateOf<FirebaseUser?>(repository.currentUser)
+        private set
+    var showRegister by androidx.compose.runtime.mutableStateOf(false)
+        private set
+
+    fun onLoginEmailChange(value: String) {
+        loginState = loginState.copy(
+            email = value,
+            emailError = if (isValidEmail(value)) null else "Invalid email"
+        )
+    }
+
+    fun onLoginPasswordChange(value: String) {
+        loginState = loginState.copy(
+            password = value,
+            passwordError = if (value.length >= 6) null else "Password too short"
+        )
+    }
+
+    fun onRegisterNameChange(value: String) {
+        registerState = registerState.copy(
+            name = value,
+            nameError = if (value.isNotBlank()) null else "Name required"
+        )
+    }
+
+    fun onRegisterEmailChange(value: String) {
+        registerState = registerState.copy(
+            email = value,
+            emailError = if (isValidEmail(value)) null else "Invalid email"
+        )
+    }
+
+    fun onRegisterPasswordChange(value: String) {
+        registerState = registerState.copy(
+            password = value,
+            passwordError = if (value.length >= 6) null else "Password too short"
+        )
+    }
+
+    private fun isValidEmail(value: String) = Patterns.EMAIL_ADDRESS.matcher(value).matches()
+
+    val isLoginValid: Boolean
+        get() = loginState.emailError == null && loginState.passwordError == null &&
+            loginState.email.isNotBlank() && loginState.password.isNotBlank()
+
+    val isRegisterValid: Boolean
+        get() = registerState.nameError == null && registerState.emailError == null &&
+            registerState.passwordError == null && registerState.name.isNotBlank() &&
+            registerState.email.isNotBlank() && registerState.password.isNotBlank()
+
+    fun toggleForm() {
+        showRegister = !showRegister
+    }
+
+    fun login(onSuccess: (FirebaseUser) -> Unit) {
+        if (!isLoginValid) return
+        viewModelScope.launch {
+            loginState = loginState.copy(isLoading = true, authError = null)
+            try {
+                repository.signInWithEmail(loginState.email, loginState.password)?.let {
+                    currentUser = it
+                    onSuccess(it)
+                }
+            } catch (e: Exception) {
+                loginState = loginState.copy(authError = e.message)
+            } finally {
+                loginState = loginState.copy(isLoading = false)
+            }
+        }
+    }
+
+    fun register(onSuccess: (FirebaseUser) -> Unit) {
+        if (!isRegisterValid) return
+        viewModelScope.launch {
+            registerState = registerState.copy(isLoading = true, authError = null)
+            try {
+                repository.registerWithEmail(
+                    registerState.name,
+                    registerState.email,
+                    registerState.password
+                )?.let {
+                    currentUser = it
+                    onSuccess(it)
+                }
+            } catch (e: Exception) {
+                registerState = registerState.copy(authError = e.message)
+            } finally {
+                registerState = registerState.copy(isLoading = false)
+            }
+        }
+    }
+
+    fun startGoogleSignIn() {
+        viewModelScope.launch {
+            loginState = loginState.copy(isLoading = true, authError = null)
+            try {
+                repository.startGoogleSignIn()?.let { currentUser = it }
+            } catch (e: Exception) {
+                loginState = loginState.copy(authError = e.message)
+            } finally {
+                loginState = loginState.copy(isLoading = false)
+            }
+        }
+    }
+
+    fun trySilentSignIn() {
+        viewModelScope.launch {
+            repository.trySilentSignIn()?.let { currentUser = it }
+        }
+    }
+
+    fun signOut() {
+        viewModelScope.launch {
+            repository.signOut()
+            currentUser = null
+        }
+    }
+}
+
+class AuthViewModelFactory(private val context: Context) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(AuthViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return AuthViewModel(AuthRepository(context)) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ credentials = "1.5.0"
 firebase-bom = "34.0.0"
 firebase-auth = "23.2.1"
 googleid = "1.1.1"
+securityCrypto = "1.1.0-alpha06"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +32,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 credentials              = { module = "androidx.credentials:credentials",                     version.ref = "credentials" }
 credentials-playservices = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 
 firebase-bom   = { group = "com.google.firebase", name = "firebase-bom",  version.ref = "firebase-bom" }
 firebase-auth  = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebase-auth" }


### PR DESCRIPTION
## Summary
- move login/register logic into new `AuthViewModel` with validation and loading state
- overhaul auth screens using Material 3 cards, inline errors, and disabled buttons
- refactor `MainActivity` to use the view model, secure credential storage, and animated transitions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ef2c82c488329a608bbc86be6f237