### PR TITLE
refactor: use version catalog for material icons

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     implementation(libs.credentials)
     implementation(libs.credentials.playservices)
     implementation(libs.googleid)
-    implementation("androidx.compose.material:material-icons-extended")
+    implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.security.crypto)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 credentials              = { module = "androidx.credentials:credentials",                     version.ref = "credentials" }
 credentials-playservices = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }


### PR DESCRIPTION
## Summary
- add material-icons-extended to version catalog
- reference new alias for material icons dependency

## Testing
- `./gradlew build` *(fails: Could not determine the dependencies of task ':app:compileDebugJavaWithJavac'. Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_688f2d500c78832984b86be6b27d3fc8