### PR TITLE
feat: bypass login for testing

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
@@ -49,6 +49,7 @@ class MainActivity : ComponentActivity() {
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )
     }
+    private val skipAuthForTesting = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -58,8 +59,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             val currentUser = viewModel.currentUser
             val showRegister = viewModel.showRegister
+            val needsAuth = currentUser == null && !skipAuthForTesting
 
-            AnimatedContent(targetState = currentUser == null, label = "auth") { needsAuth ->
+            AnimatedContent(targetState = needsAuth, label = "auth") { needsAuth ->
                 if (needsAuth) {
                     AnimatedContent(
                         targetState = showRegister,


### PR DESCRIPTION
## Summary
- add testing flag to skip authentication
- show dashboard immediately when skipping login

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f3e1535648329b0ae3c8d2913815e