### PR TITLE
Add kotlin-reflect dependency for KSP build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.kotlin.reflect)
     implementation(platform(libs.firebase.bom))   // <-- BOM now comes from catalog
     implementation(libs.firebase.auth.ktx)        // <-- version is inherited from the BOM
     implementation(libs.credentials)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 credentials              = { module = "androidx.credentials:credentials",                     version.ref = "credentials" }
 credentials-playservices = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }


### PR DESCRIPTION
## Summary
- include kotlin-reflect library in version catalog
- apply kotlin-reflect dependency in app module

## Testing
- `./gradlew clean assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4e84eacc83298593265130f6f926