### PR TITLE
Ensure KSP classpath has kotlin-reflect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     ksp(libs.androidx.room.compiler)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    // Ensure KSP has access to Kotlin reflection classes
+    ksp(libs.kotlin.reflect)
     testImplementation(libs.junit)
     testImplementation(libs.androidx.room.testing)
     testImplementation(libs.androidx.test.core)


### PR DESCRIPTION
## Summary
- Ensure KSP tasks have access to Kotlin reflection by adding `ksp(libs.kotlin.reflect)`

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f53e1ff288329b69df45d2bea899c