### PR TITLE
Switch annotation processing to KAPT

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.hilt.android)
     id("com.google.gms.google-services")
 }
@@ -47,6 +47,10 @@ kotlin {
     }
 }
 
+kapt {
+    correctErrorTypes = true
+}
+
 dependencies {
 
     implementation(libs.androidx.core.ktx)
@@ -67,11 +71,9 @@ dependencies {
     implementation(libs.androidx.security.crypto)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
-    ksp(libs.androidx.room.compiler)
+    kapt(libs.androidx.room.compiler)
     implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-    // Ensure KSP has access to Kotlin reflection classes
-    ksp(libs.kotlin.reflect)
+    kapt(libs.hilt.compiler)
     testImplementation(libs.junit)
     testImplementation(libs.androidx.room.testing)
     testImplementation(libs.androidx.test.core)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
     id("com.google.gms.google-services") version "4.4.3" apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ googleid = "1.1.1"
 securityCrypto = "1.1.0"
 room = "2.7.2"
 hilt = "2.57"
-ksp = "2.2.0-2.0.2"
 androidxTestCore = "1.7.0"
 robolectric = "4.15.1"
 
@@ -59,5 +58,5 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- replace KSP plugin with Kotlin KAPT
- update dependencies to use kapt for Hilt and Room
- configure KAPT to correct error types

## Testing
- `./gradlew --project-cache-dir /tmp/gradle-cache assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f561a362c8329a5f179da375ae778