### PR TITLE
Switch from KSP to KAPT

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.hilt.android)
     id("com.google.gms.google-services")
 }
@@ -57,7 +57,6 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.kotlin.reflect) // Ensure KSP has access to Kotlin reflection classes
     implementation(platform(libs.firebase.bom))   // <-- BOM now comes from catalog
     implementation(libs.firebase.auth.ktx)        // <-- version is inherited from the BOM
     implementation(libs.credentials)
@@ -67,9 +66,9 @@ dependencies {
     implementation(libs.androidx.security.crypto)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
-    ksp(libs.androidx.room.compiler)
+    kapt(libs.androidx.room.compiler)
     implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
+    kapt(libs.hilt.compiler)
     testImplementation(libs.junit)
     testImplementation(libs.androidx.room.testing)
     testImplementation(libs.androidx.test.core)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
     id("com.google.gms.google-services") version "4.4.3" apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ googleid = "1.1.1"
 securityCrypto = "1.1.0"
 room = "2.7.2"
 hilt = "2.57"
-ksp = "2.2.0-2.0.2"
 androidxTestCore = "1.7.0"
 robolectric = "4.15.1"
 
@@ -35,7 +34,6 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
-kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 credentials              = { module = "androidx.credentials:credentials",                     version.ref = "credentials" }
 credentials-playservices = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
@@ -59,5 +57,5 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- migrate build to Kotlin KAPT instead of KSP
- update Room and Hilt processors to use kapt

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f5dc643008329b41efc1841bc84a2