### PR TITLE
Force JavaPoet 1.13.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,3 +6,13 @@ plugins {
     alias(libs.plugins.kotlin.kapt) apply false
     id("com.google.gms.google-services") version "4.4.3" apply false
 }
+
+// Work around NoSuchMethodError for ClassName.canonicalName by forcing
+// a known compatible version of JavaPoet across all modules.
+allprojects {
+    configurations.all {
+        resolutionStrategy {
+            force("com.squareup:javapoet:1.13.0")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Force JavaPoet 1.13.0 across all modules to avoid ClassName.canonicalName NoSuchMethodError

## Testing
- `./gradlew app:dependencies --configuration kapt`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68902d466d3083299693aa51b241cdab