### PR TITLE
Add subject chooser and dashboard navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.navigation.compose)
     implementation(platform(libs.firebase.bom))   // <-- BOM now comes from catalog
     implementation(libs.firebase.auth.ktx)        // <-- version is inherited from the BOM
     implementation(libs.credentials)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
@@ -18,7 +18,19 @@ import com.concepts_and_quizzes.cds.auth.AuthViewModelFactory
 import com.concepts_and_quizzes.cds.auth.LoginScreen
 import com.concepts_and_quizzes.cds.auth.RegisterScreen
 import com.concepts_and_quizzes.cds.core.theme.CDSTheme
-import com.concepts_and_quizzes.cds.ui.dashboard.DashboardScreen
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.concepts_and_quizzes.cds.core.components.CdsBottomNavBar
+import com.concepts_and_quizzes.cds.ui.concepts.ConceptsScreen
+import com.concepts_and_quizzes.cds.ui.dashboard.GlobalDashboardScreen
+import com.concepts_and_quizzes.cds.ui.english.EnglishScreen
+import com.concepts_and_quizzes.cds.ui.subjectchooser.SubjectChooserScreen
 
 class MainActivity : ComponentActivity() {
     private val viewModel: AuthViewModel by viewModels { AuthViewModelFactory(this) }
@@ -77,13 +89,29 @@ class MainActivity : ComponentActivity() {
                             }
                         }
                     } else {
-                        DashboardScreen(
-                            name = currentUser?.displayName ?: "",
-                            onSignOut = {
-                                viewModel.signOut()
-                                prefs.edit { clear() }
+                        val navController = rememberNavController()
+                        val navBackStackEntry by navController.currentBackStackEntryAsState()
+                        val currentRoute = navBackStackEntry?.destination?.route
+                        val showBottomBar = currentRoute != "subjectChooser"
+
+                        Scaffold(
+                            bottomBar = {
+                                if (showBottomBar) {
+                                    CdsBottomNavBar(navController)
+                                }
                             }
-                        )
+                        ) { padding ->
+                            NavHost(
+                                navController = navController,
+                                startDestination = "subjectChooser",
+                                modifier = Modifier.padding(padding)
+                            ) {
+                                composable("subjectChooser") { SubjectChooserScreen(navController) }
+                                composable("dashboard") { GlobalDashboardScreen(navController) }
+                                composable("concepts") { ConceptsScreen() }
+                                composable("english") { EnglishScreen() }
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/components/BottomNavBar.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/components/BottomNavBar.kt
@@ -1,9 +1,46 @@
 package com.concepts_and_quizzes.cds.core.components
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.compose.ui.graphics.vector.ImageVector
+
+private data class NavItem(val label: String, val icon: ImageVector, val route: String)
 
 @Composable
-fun CdsBottomNavBar() {
-    NavigationBar { }
+fun CdsBottomNavBar(navController: NavHostController) {
+    val items = listOf(
+        NavItem("Dashboard", Icons.Filled.Home, "dashboard"),
+        NavItem("Concepts", Icons.Filled.MenuBook, "concepts"),
+        NavItem("English", Icons.Filled.Language, "english")
+    )
+    NavigationBar {
+        val navBackStackEntry = navController.currentBackStackEntryAsState().value
+        val currentRoute = navBackStackEntry?.destination?.route
+        items.forEach { item ->
+            NavigationBarItem(
+                selected = currentRoute == item.route,
+                onClick = {
+                    navController.navigate(item.route) {
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                icon = { Icon(imageVector = item.icon, contentDescription = item.label) },
+                label = { Text(text = item.label) }
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/dashboard/GlobalDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/dashboard/GlobalDashboardScreen.kt
@@ -1,0 +1,25 @@
+package com.concepts_and_quizzes.cds.ui.dashboard
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+
+@Composable
+fun GlobalDashboardScreen(navController: NavHostController) {
+    Scaffold { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "Dashboard")
+        }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/subjectchooser/SubjectChooserScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/subjectchooser/SubjectChooserScreen.kt
@@ -1,4 +1,4 @@
-package com.concepts_and_quizzes.cds.ui.dashboard
+package com.concepts_and_quizzes.cds.ui.subjectchooser
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -7,34 +7,28 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.concepts_and_quizzes.cds.R
+import androidx.navigation.NavHostController
 
 @Composable
-fun DashboardScreen(name: String, onSignOut: () -> Unit) {
+fun SubjectChooserScreen(navController: NavHostController) {
     Scaffold { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding)
-                .padding(32.dp),
+                .padding(padding),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(
-                text = stringResource(id = R.string.welcome_message, name),
-                style = MaterialTheme.typography.headlineMedium,
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            Button(onClick = onSignOut) {
-                Text(text = stringResource(id = R.string.sign_out))
+            Text(text = "Choose a Subject")
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = { navController.navigate("dashboard") }) {
+                Text(text = "Go to Dashboard")
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ room = "2.7.2"
 hilt = "2.57"
 androidxTestCore = "1.7.0"
 robolectric = "4.15.1"
+navigationCompose = "2.8.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +35,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 credentials              = { module = "androidx.credentials:credentials",                     version.ref = "credentials" }
 credentials-playservices = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }


### PR DESCRIPTION
## Summary
- start app at new subject chooser screen
- add global dashboard route and bottom navigation bar
- include navigation compose dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68904a6c3f3c8329b8cf66e1f5adcec0