### PR TITLE
Add global dashboard with progress tracking

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/model/SubjectProgress.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/model/SubjectProgress.kt
@@ -1,0 +1,14 @@
+package com.concepts_and_quizzes.cds.core.model
+
+import com.concepts_and_quizzes.cds.core.model.Subject
+
+/**
+ * Represents a user's progress for a particular subject.
+ *
+ * @param subject the subject for which progress is tracked
+ * @param percentComplete value between 0f and 1f representing completion percentage
+ */
+data class SubjectProgress(
+    val subject: Subject,
+    val percentComplete: Float
+)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/repository/ProgressRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/repository/ProgressRepository.kt
@@ -1,0 +1,16 @@
+package com.concepts_and_quizzes.cds.data.repository
+
+import com.concepts_and_quizzes.cds.core.model.Subject
+import com.concepts_and_quizzes.cds.core.model.SubjectProgress
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * Repository that provides progress information for all subjects.
+ * Currently returns placeholder progress values.
+ */
+class ProgressRepository @Inject constructor() {
+    fun getAllSubjectProgress(): Flow<List<SubjectProgress>> =
+        flowOf(Subject.values().map { SubjectProgress(it, 0f) })
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/di/ProgressModule.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/di/ProgressModule.kt
@@ -1,0 +1,16 @@
+package com.concepts_and_quizzes.cds.di
+
+import com.concepts_and_quizzes.cds.data.repository.ProgressRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ProgressModule {
+    @Provides
+    @Singleton
+    fun provideProgressRepository(): ProgressRepository = ProgressRepository()
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/dashboard/DashboardViewModel.kt
@@ -1,0 +1,24 @@
+package com.concepts_and_quizzes.cds.ui.dashboard
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.concepts_and_quizzes.cds.core.model.SubjectProgress
+import com.concepts_and_quizzes.cds.data.repository.ProgressRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class DashboardViewModel @Inject constructor(
+    progressRepository: ProgressRepository
+) : ViewModel() {
+    val subjectProgress: StateFlow<List<SubjectProgress>> =
+        progressRepository.getAllSubjectProgress().stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/dashboard/GlobalDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/dashboard/GlobalDashboardScreen.kt
@@ -1,25 +1,43 @@
 package com.concepts_and_quizzes.cds.ui.dashboard
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 
 @Composable
-fun GlobalDashboardScreen(navController: NavHostController) {
-    Scaffold { padding ->
-        Box(
+fun GlobalDashboardScreen(
+    navController: NavHostController,
+    viewModel: DashboardViewModel = hiltViewModel()
+) {
+    val progress by viewModel.subjectProgress.collectAsState()
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Dashboard") }) }
+    ) { padding ->
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding),
-            contentAlignment = Alignment.Center
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Text(text = "Dashboard")
+            items(progress) { subjectProgress ->
+                ProgressCard(progress = subjectProgress) {
+                    navController.navigate("subject/${subjectProgress.subject.id}/dashboard")
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/dashboard/ProgressCard.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/dashboard/ProgressCard.kt
@@ -1,0 +1,49 @@
+package com.concepts_and_quizzes.cds.ui.dashboard
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import com.concepts_and_quizzes.cds.core.model.SubjectProgress
+import kotlin.math.roundToInt
+
+@Composable
+fun ProgressCard(progress: SubjectProgress, onViewDetails: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                painter = painterResource(id = progress.subject.iconRes),
+                contentDescription = progress.subject.displayName,
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(progress.subject.displayName, style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            Box(contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(progress = progress.percentComplete)
+                Text(text = "${(progress.percentComplete * 100).roundToInt()}%")
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = onViewDetails) {
+                Text("View Details")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/home/SubjectChooserScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/home/SubjectChooserScreen.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -24,7 +27,18 @@ fun SubjectChooserScreen(
 ) {
     val subs by viewModel.subscriptions.collectAsState()
 
-    Scaffold { padding ->
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Subjects") },
+                actions = {
+                    TextButton(onClick = { navController.navigate("dashboard") }) {
+                        Text("Go to Dashboard")
+                    }
+                }
+            )
+        }
+    ) { padding ->
         LazyVerticalGrid(
             columns = GridCells.Fixed(2),
             modifier = Modifier


### PR DESCRIPTION
## Summary
- Add `SubjectProgress` model, repository, and Hilt module
- Implement `DashboardViewModel`, `ProgressCard` component, and enhanced `GlobalDashboardScreen` with progress list
- Add "Go to Dashboard" link on `SubjectChooserScreen`

## Testing
- `./gradlew test` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68904ef524e88329b33bd1f30a613798