### PR TITLE
Handle missing question options

### DIFF
--- a/app/src/main/assets/CDS_II_2024_English_SetA.json
+++ b/app/src/main/assets/CDS_II_2024_English_SetA.json
@@ -638,14 +638,15 @@
     {
       "question_number": 33,
       "question": "S1: Startup India is a flagship initiative of the Government of India. S6: Under the Startup India scheme, eligible companies can get recognized as startups in order to access a host of tax benefits, easier compliance, IPR fast-tracking and other benefits. P: These programmes are managed by a dedicated Startup India team, which reports to DPIIT. Q: It envisions transforming India into a country of job creators instead ofjob seekers. R: It intends to catalyse the startup culture and build a strong and inclusive ecosystem for innovation and entrepreneurship in India. S: Launched in 2016, Startup India has rolled out several programmes with the objective of supporting entrepreneurs and building up a robust startup ecosystem. The correct sequence should be :",
-      "options": {
-        "A": "PQSR",
-        "B": "PSQR",
-        "C": "PSRQ"
-      },
-      "correct_answer": "B",
-      "topic": "Comprehension",
-      "sub_topic": "Para-jumbles",
+    "options": {
+      "A": "PQSR",
+      "B": "PSQR",
+      "C": "PSRQ",
+      "D": "PQRS"
+    },
+    "correct_answer": "B",
+    "topic": "Comprehension",
+    "sub_topic": "Para-jumbles",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/SeedUtil.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/SeedUtil.kt
@@ -59,11 +59,12 @@ class SeedUtil @Inject constructor(
             val qs = mutableListOf<PyqpQuestionEntity>()
             for (i in 0 until questionsJson.length()) {
                 val q = questionsJson.getJSONObject(i)
-                val opts = q.getJSONObject("options")
-                val correct = when (q.getString("correct_answer")) {
+                val opts = q.optJSONObject("options") ?: JSONObject()
+                val correct = when (q.optString("correct_answer")) {
                     "A" -> 0
                     "B" -> 1
                     "C" -> 2
+                    "D" -> 3
                     else -> 3
                 }
                 qs.add(
@@ -71,10 +72,10 @@ class SeedUtil @Inject constructor(
                         qid = "$file-${q.getInt("question_number")}",
                         paperId = file,
                         question = q.getString("question"),
-                        optionA = opts.getString("A"),
-                        optionB = opts.getString("B"),
-                        optionC = opts.getString("C"),
-                        optionD = opts.getString("D"),
+                        optionA = opts.optString("A"),
+                        optionB = opts.optString("B"),
+                        optionC = opts.optString("C"),
+                        optionD = opts.optString("D"),
                         correctIndex = correct
                     )
                 )


### PR DESCRIPTION
## Summary
- Safeguard seeding by using `optJSONObject`/`optString` when reading PYQP options to tolerate absent choices.
- Add missing option D for question 33 in `CDS_II_2024_English_SetA.json` to provide a complete set of answers.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e0cde13c8329a8edc20ec42b699e