### PR TITLE
Add section intro and collapsible headers for quiz

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabase.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabase.kt
@@ -14,7 +14,7 @@ import com.concepts_and_quizzes.cds.data.english.model.PyqpQuestionEntity
         PyqpQuestionEntity::class,
         PyqpProgress::class
     ],
-    version = 3
+    version = 4
 )
 abstract class EnglishDatabase : RoomDatabase() {
     abstract fun topicDao(): EnglishTopicDao

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
@@ -13,12 +13,18 @@ data class PyqpQuestionEntity(
     val optionB: String,
     val optionC: String,
     val optionD: String,
-    val correctIndex: Int
+    val correctIndex: Int,
+    val direction: String? = null,
+    val passageTitle: String? = null,
+    val passageText: String? = null
 )
 
 fun PyqpQuestionEntity.toDomain() = PyqpQuestion(
     id = qid,
     text = question,
     options = listOf(optionA, optionB, optionC, optionD),
-    correct = correctIndex
+    correct = correctIndex,
+    direction = direction,
+    passage = passageText,
+    passageTitle = passageTitle
 )

--- a/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/PyqpQuestion.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/PyqpQuestion.kt
@@ -4,5 +4,8 @@ data class PyqpQuestion(
     val id: String,
     val text: String,
     val options: List<String>,
-    val correct: Int
+    val correct: Int,
+    val direction: String? = null,
+    val passage: String? = null,
+    val passageTitle: String? = null
 )

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -2,12 +2,17 @@ package com.concepts_and_quizzes.cds.ui.english.pyqp
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.concepts_and_quizzes.cds.domain.english.PyqpQuestion
 
 @Composable
 fun QuizScreen(
@@ -18,6 +23,7 @@ fun QuizScreen(
     val ui by vm.ui.collectAsState()
     when (val state = ui) {
         is QuizViewModel.QuizUi.Loading -> CircularProgressIndicator()
+        is QuizViewModel.QuizUi.SectionIntro -> SectionIntroView(state, vm::continueFromIntro)
         is QuizViewModel.QuizUi.Question -> QuestionView(state, vm)
         is QuizViewModel.QuizUi.Result -> ResultView(state) {
             vm.saveProgress()
@@ -28,7 +34,8 @@ fun QuizScreen(
 
 @Composable
 private fun QuestionView(q: QuizViewModel.QuizUi.Question, vm: QuizViewModel) {
-    Column(Modifier.padding(16.dp)) {
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        CollapsibleHeader(q.question)
         Text("Q${q.index + 1}. ${q.question.text}")
         q.question.options.forEachIndexed { idx, opt ->
             RadioButtonRow(
@@ -39,6 +46,78 @@ private fun QuestionView(q: QuizViewModel.QuizUi.Question, vm: QuizViewModel) {
         }
         Spacer(Modifier.height(16.dp))
         Button(onClick = vm::next) { Text("Next") }
+    }
+}
+
+@Composable
+private fun SectionIntroView(intro: QuizViewModel.QuizUi.SectionIntro, onContinue: () -> Unit) {
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Column {
+                intro.direction?.let {
+                    Text("Directions", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Text(it)
+                    if (intro.passage != null) Spacer(Modifier.height(16.dp))
+                }
+                intro.passage?.let {
+                    Text(intro.passageTitle ?: "Passage", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Text(it)
+                }
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = onContinue, modifier = Modifier.align(Alignment.End)) { Text("Continue") }
+    }
+}
+
+@Composable
+private fun CollapsibleHeader(q: PyqpQuestion) {
+    val hasText = q.direction != null || q.passage != null
+    if (!hasText) return
+    var expanded by remember(q.id) { mutableStateOf(false) }
+    val label = if (q.passage != null) "Show passage" else "Show direction"
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { expanded = !expanded }
+    ) {
+        Text(
+            if (expanded) "Hide ${if (q.passage != null) "passage" else "direction"}" else label,
+            modifier = Modifier.padding(8.dp)
+        )
+    }
+    if (expanded) {
+        val maxHeight = LocalConfiguration.current.screenHeightDp.dp * 0.7f
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = maxHeight)
+        ) {
+            Column(
+                Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp)
+            ) {
+                q.direction?.let {
+                    Text("Directions", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Text(it)
+                    if (q.passage != null) Spacer(Modifier.height(16.dp))
+                }
+                q.passage?.let {
+                    Text(q.passageTitle ?: "Passage", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Text(it)
+                }
+            }
+        }
+        Spacer(Modifier.height(16.dp))
     }
 }
 


### PR DESCRIPTION
## Summary
- persist direction and passage text for PYQP questions
- show intro pages before new directions or passages
- add collapsible headers to re-read direction or passage during questions

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task :app:testDebugUnitTest. Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_6890ed2452748329a11f63373054eb64