### PR TITLE
Show directions and passages in quiz questions

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -111,6 +111,18 @@ private fun QuestionPage(
     onSelect: (Int) -> Unit
 ) {
     Column(Modifier.fillMaxSize()) {
+        question.direction?.let {
+            Text(it)
+            Spacer(Modifier.height(8.dp))
+        }
+        if (question.passage != null) {
+            question.passageTitle?.let {
+                Text(it, style = MaterialTheme.typography.titleMedium)
+                Spacer(Modifier.height(4.dp))
+            }
+            Text(question.passage)
+            Spacer(Modifier.height(8.dp))
+        }
         Text("Q${index + 1}. ${question.text}")
         Spacer(Modifier.height(8.dp))
         question.options.forEachIndexed { idx, opt ->


### PR DESCRIPTION
## Summary
- Display question directions when provided in PYQP quiz page
- Render passage title and text above relevant questions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890fa64272083299f7a3b164808dd03