### PR TITLE
Enable scrolling for long quiz questions

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -150,7 +150,11 @@ private fun QuestionPage(
     LaunchedEffect(currentPage) { show = false }
 
     val hasInfo = question.direction != null || question.passage != null
-    Column(Modifier.fillMaxSize()) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+    ) {
         if (hasInfo) {
             val label = if (question.passage != null) {
                 if (show) "Hide" else "Show passage"


### PR DESCRIPTION
## Summary
- Make quiz questions vertically scrollable so options remain accessible

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689103a5fba48329aa724147c19a1823