### PR TITLE
Shuffle quiz options with answer metadata

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
@@ -2,6 +2,7 @@ package com.concepts_and_quizzes.cds.data.english.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.concepts_and_quizzes.cds.domain.english.AnswerOption
 import com.concepts_and_quizzes.cds.domain.english.PyqpQuestion
 
 @Entity(tableName = "pyqp_questions")
@@ -22,8 +23,12 @@ data class PyqpQuestionEntity(
 fun PyqpQuestionEntity.toDomain() = PyqpQuestion(
     id = qid,
     text = question,
-    options = listOf(optionA, optionB, optionC, optionD),
-    correct = correctIndex,
+    options = listOf(
+        AnswerOption(optionA, correctIndex == 0),
+        AnswerOption(optionB, correctIndex == 1),
+        AnswerOption(optionC, correctIndex == 2),
+        AnswerOption(optionD, correctIndex == 3)
+    ),
     direction = direction,
     passage = passageText,
     passageTitle = passageTitle

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/repo/PyqpRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/repo/PyqpRepository.kt
@@ -3,6 +3,7 @@ package com.concepts_and_quizzes.cds.data.english.repo
 import com.concepts_and_quizzes.cds.data.english.db.PyqpDao
 import com.concepts_and_quizzes.cds.data.english.model.toDomain
 import com.concepts_and_quizzes.cds.domain.english.PyqpQuestion
+import com.concepts_and_quizzes.cds.domain.english.shuffledOptions
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -16,7 +17,7 @@ class PyqpRepository @Inject constructor(
         }
 
     fun getQuestions(paperId: String): Flow<List<PyqpQuestion>> =
-        dao.getQuestionsByPaper(paperId).map { list -> list.map { it.toDomain() } }
+        dao.getQuestionsByPaper(paperId).map { list -> list.map { it.toDomain().shuffledOptions() } }
 }
 
 data class PyqpPaper(val id: String, val year: Int)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/AnswerOption.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/AnswerOption.kt
@@ -1,0 +1,6 @@
+package com.concepts_and_quizzes.cds.domain.english
+
+data class AnswerOption(
+    val text: String,
+    val isCorrect: Boolean
+)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/PyqpQuestion.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/PyqpQuestion.kt
@@ -3,9 +3,11 @@ package com.concepts_and_quizzes.cds.domain.english
 data class PyqpQuestion(
     val id: String,
     val text: String,
-    val options: List<String>,
-    val correct: Int,
+    val options: List<AnswerOption>,
     val direction: String? = null,
     val passage: String? = null,
     val passageTitle: String? = null
 )
+
+fun PyqpQuestion.shuffledOptions(): PyqpQuestion =
+    copy(options = options.shuffled())

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -194,7 +194,7 @@ private fun QuestionPage(
         Text("Q$number. ${question.text}")
         Spacer(Modifier.height(8.dp))
         question.options.forEachIndexed { idx, opt ->
-            OptionCard(selected == idx, opt) { onSelect(idx) }
+            OptionCard(selected == idx, opt.text) { onSelect(idx) }
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -135,12 +135,12 @@ class QuizViewModel @Inject constructor(
     }
 
     fun submit() {
-        val correct = answers.count { (i, ans) -> questions[i].correct == ans }
+        val correct = answers.count { (i, ans) -> questions[i].options[ans].isCorrect }
         _ui.value = QuizUi.Result(correct, questions.size)
     }
 
     fun saveProgress() {
-        val correct = answers.count { (i, ans) -> questions[i].correct == ans }
+        val correct = answers.count { (i, ans) -> questions[i].options[ans].isCorrect }
         viewModelScope.launch {
             progressDao.upsert(
                 PyqpProgress(paperId = paperId, correct = correct, attempted = questions.size)

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
@@ -51,12 +51,23 @@ class QuizViewModelTest {
         }
         val vm = QuizViewModel(repo, progressDao, SavedStateHandle(mapOf("paperId" to "paper")))
         advanceUntilIdle()
-        vm.select(0)
+
+        val q1 = vm.pageContent(0) as QuizViewModel.QuizPage.Question
+        val idx0 = q1.question.options.indexOfFirst { it.isCorrect }
+        vm.select(idx0)
         vm.next()
-        vm.select(1)
+
+        val q2 = vm.pageContent(1) as QuizViewModel.QuizPage.Question
+        val idx1 = q2.question.options.indexOfFirst { it.isCorrect }
+        vm.select(idx1)
         vm.next()
-        vm.select(3) // wrong
+
+        val q3 = vm.pageContent(2) as QuizViewModel.QuizPage.Question
+        val correctIdx = q3.question.options.indexOfFirst { it.isCorrect }
+        val wrongIdx = (correctIdx + 1) % q3.question.options.size
+        vm.select(wrongIdx)
         vm.next()
+
         val res = vm.ui.value as QuizViewModel.QuizUi.Result
         assertEquals(2, res.correct)
         assertEquals(3, res.total)


### PR DESCRIPTION
## Summary
- Introduce `AnswerOption` model and update `PyqpQuestion` to carry option correctness
- Shuffle options when loading questions and score using `isCorrect`
- Adjust UI and tests to work with shuffled option set

## Testing
- `./gradlew test` *(fails: EnglishDatabaseTest and PyqpDaoTest due to MavenArtifactFetcher java.net.SocketException)*
- `./gradlew :app:testReleaseUnitTest --tests com.concepts_and_quizzes.cds.ui.english.pyqp.QuizViewModelTest`


------
https://chatgpt.com/codex/tasks/task_e_689106d7df5083299654c37e6617171b