### PR TITLE
Add local analytics engine with Room

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
@@ -1,0 +1,112 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Data access object for [AttemptLogEntity] and analytics queries.
+ */
+@Dao
+interface AttemptLogDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(attempts: List<AttemptLogEntity>)
+
+    // --- Topic snapshot ---
+    @Query(
+        """
+        SELECT q.topicId AS topicId,
+               COUNT(*) AS total,
+               SUM(CASE WHEN a.correct THEN 1 ELSE 0 END) AS correct,
+               AVG(a.durationMs) AS avgDurationMs,
+               SUM(CASE WHEN a.flagged THEN 1 ELSE 0 END) AS flagged
+        FROM attempt_log a
+        JOIN english_questions q ON a.qid = q.qid
+        GROUP BY q.topicId
+        """
+    )
+    fun getTopicSnapshot(): Flow<List<TopicSnapshotDb>>
+
+    // --- Trend over time ---
+    @Query(
+        """
+        SELECT q.topicId AS topicId,
+               strftime('%Y-%m-%d', a.timestamp/1000, 'unixepoch') AS day,
+               COUNT(*) AS total,
+               SUM(CASE WHEN a.correct THEN 1 ELSE 0 END) AS correct
+        FROM attempt_log a
+        JOIN english_questions q ON a.qid = q.qid
+        WHERE a.timestamp >= :startTime
+        GROUP BY q.topicId, day
+        ORDER BY day
+        """
+    )
+    fun getTrend(startTime: Long): Flow<List<TopicTrendPointDb>>
+
+    // --- Difficulty per topic ---
+    @Query(
+        """
+        WITH per_question AS (
+            SELECT q.qid AS qid,
+                   q.topicId AS topicId,
+                   AVG(CASE WHEN a.correct THEN 1.0 ELSE 0.0 END) AS p
+            FROM attempt_log a
+            JOIN english_questions q ON a.qid = q.qid
+            GROUP BY q.qid
+        )
+        SELECT topicId,
+               AVG(p) AS difficulty
+        FROM per_question
+        GROUP BY topicId
+        """
+    )
+    fun getDifficulty(): Flow<List<TopicDifficultyDb>>
+
+    // --- Attempts with quiz total score for discrimination computation ---
+    @Query(
+        """
+        WITH quiz_scores AS (
+            SELECT quizId,
+                   SUM(CASE WHEN correct THEN 1 ELSE 0 END) AS totalScore
+            FROM attempt_log
+            GROUP BY quizId
+        )
+        SELECT a.qid AS qid,
+               a.correct AS correct,
+               qs.totalScore AS totalScore
+        FROM attempt_log a
+        JOIN quiz_scores qs ON a.quizId = qs.quizId
+        """
+    )
+    fun getAttemptsWithScore(): Flow<List<AttemptWithScoreDb>>
+}
+
+// --- Data classes for query results ---
+
+data class TopicSnapshotDb(
+    val topicId: String,
+    val total: Int,
+    val correct: Int,
+    val avgDurationMs: Double,
+    val flagged: Int
+)
+
+data class TopicTrendPointDb(
+    val topicId: String,
+    val day: String,
+    val total: Int,
+    val correct: Int
+)
+
+data class TopicDifficultyDb(
+    val topicId: String,
+    val difficulty: Double
+)
+
+data class AttemptWithScoreDb(
+    val qid: String,
+    val correct: Boolean,
+    val totalScore: Int
+)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogEntity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogEntity.kt
@@ -1,0 +1,25 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Room entity representing a single question attempt. One row per question per quiz attempt.
+ */
+@Entity(
+    tableName = "attempt_log",
+    indices = [
+        Index(value = ["qid"], name = "idx_attempt_qid"),
+        Index(value = ["timestamp"], name = "idx_attempt_time")
+    ]
+)
+data class AttemptLogEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val qid: String,
+    val quizId: String,
+    val correct: Boolean,
+    val flagged: Boolean,
+    val durationMs: Int,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/AnalyticsRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/AnalyticsRepository.kt
@@ -1,0 +1,61 @@
+package com.concepts_and_quizzes.cds.data.analytics.repo
+
+import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
+import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
+import com.concepts_and_quizzes.cds.domain.analytics.QuestionDiscrimination
+import com.concepts_and_quizzes.cds.domain.analytics.TopicDifficulty
+import com.concepts_and_quizzes.cds.domain.analytics.TopicStat
+import com.concepts_and_quizzes.cds.domain.analytics.TopicTrendPoint
+import javax.inject.Inject
+import kotlin.math.pow
+import kotlin.math.sqrt
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Repository exposing analytics metrics as [Flow]s.
+ */
+class AnalyticsRepository @Inject constructor(
+    private val attemptDao: AttemptLogDao
+) {
+    suspend fun insertAttempts(attempts: List<AttemptLogEntity>) =
+        attemptDao.insertAll(attempts)
+
+    fun getTopicSnapshot(): Flow<List<TopicStat>> =
+        attemptDao.getTopicSnapshot().map { list ->
+            list.map {
+                TopicStat(it.topicId, it.total, it.correct, it.avgDurationMs, it.flagged)
+            }
+        }
+
+    fun getTrend(periodDays: Int = 30): Flow<List<TopicTrendPoint>> {
+        val startTime = System.currentTimeMillis() - periodDays * 24L * 60 * 60 * 1000
+        return attemptDao.getTrend(startTime).map { list ->
+            list.map { TopicTrendPoint(it.topicId, it.day, it.total, it.correct) }
+        }
+    }
+
+    fun getDifficulty(): Flow<List<TopicDifficulty>> =
+        attemptDao.getDifficulty().map { list ->
+            list.map { TopicDifficulty(it.topicId, it.difficulty) }
+        }
+
+    fun getDiscrimination(): Flow<List<QuestionDiscrimination>> =
+        attemptDao.getAttemptsWithScore().map { list ->
+            val grouped = list.groupBy { it.qid }
+            grouped.map { (qid, attempts) ->
+                val xs = attempts.map { if (it.correct) 1.0 else 0.0 }
+                val ys = attempts.map { it.totalScore.toDouble() }
+                val meanX = xs.average()
+                val meanY = ys.average()
+                val covariance = xs.indices.sumOf { i -> (xs[i] - meanX) * (ys[i] - meanY) } /
+                    (xs.size - 1).coerceAtLeast(1)
+                val stdX = sqrt(xs.sumOf { (it - meanX).pow(2) } /
+                    (xs.size - 1).coerceAtLeast(1))
+                val stdY = sqrt(ys.sumOf { (it - meanY).pow(2) } /
+                    (ys.size - 1).coerceAtLeast(1))
+                val corr = if (stdX == 0.0 || stdY == 0.0) 0.0 else covariance / (stdX * stdY)
+                QuestionDiscrimination(qid, corr)
+            }
+        }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabase.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabase.kt
@@ -6,19 +6,22 @@ import com.concepts_and_quizzes.cds.data.english.model.EnglishQuestionEntity
 import com.concepts_and_quizzes.cds.data.english.model.EnglishTopicEntity
 import com.concepts_and_quizzes.cds.data.english.model.PyqpProgress
 import com.concepts_and_quizzes.cds.data.english.model.PyqpQuestionEntity
+import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
 
 @Database(
     entities = [
         EnglishTopicEntity::class,
         EnglishQuestionEntity::class,
         PyqpQuestionEntity::class,
-        PyqpProgress::class
+        PyqpProgress::class,
+        AttemptLogEntity::class
     ],
-    version = 4
+    version = 5
 )
 abstract class EnglishDatabase : RoomDatabase() {
     abstract fun topicDao(): EnglishTopicDao
     abstract fun questionDao(): EnglishQuestionDao
     abstract fun pyqpDao(): PyqpDao
     abstract fun pyqpProgressDao(): PyqpProgressDao
+    abstract fun attemptLogDao(): com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabaseModule.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabaseModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room.Room
 import com.concepts_and_quizzes.cds.data.english.repo.EnglishRepository
 import com.concepts_and_quizzes.cds.data.english.repo.PyqpRepository
+import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
+import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,6 +36,9 @@ object EnglishDatabaseModule {
     fun providePyqpProgressDao(db: EnglishDatabase): PyqpProgressDao = db.pyqpProgressDao()
 
     @Provides
+    fun provideAttemptLogDao(db: EnglishDatabase): AttemptLogDao = db.attemptLogDao()
+
+    @Provides
     @Singleton
     fun provideEnglishRepository(
         topicDao: EnglishTopicDao,
@@ -43,4 +48,9 @@ object EnglishDatabaseModule {
     @Provides
     @Singleton
     fun providePyqpRepository(pyqpDao: PyqpDao): PyqpRepository = PyqpRepository(pyqpDao)
+
+    @Provides
+    @Singleton
+    fun provideAnalyticsRepository(attemptDao: AttemptLogDao): AnalyticsRepository =
+        AnalyticsRepository(attemptDao)
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/domain/analytics/QuestionDiscrimination.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/domain/analytics/QuestionDiscrimination.kt
@@ -1,0 +1,9 @@
+package com.concepts_and_quizzes.cds.domain.analytics
+
+/**
+ * Point-biserial discrimination index for a question.
+ */
+data class QuestionDiscrimination(
+    val qid: String,
+    val discrimination: Double
+)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/domain/analytics/TopicDifficulty.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/domain/analytics/TopicDifficulty.kt
@@ -1,0 +1,9 @@
+package com.concepts_and_quizzes.cds.domain.analytics
+
+/**
+ * Average difficulty per topic. Lower values mean harder questions.
+ */
+data class TopicDifficulty(
+    val topicId: String,
+    val difficulty: Double
+)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/domain/analytics/TopicStat.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/domain/analytics/TopicStat.kt
@@ -1,0 +1,12 @@
+package com.concepts_and_quizzes.cds.domain.analytics
+
+/**
+ * Aggregated statistics for a single topic.
+ */
+data class TopicStat(
+    val topicId: String,
+    val total: Int,
+    val correct: Int,
+    val avgDurationMs: Double,
+    val flagged: Int
+)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/domain/analytics/TopicTrendPoint.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/domain/analytics/TopicTrendPoint.kt
@@ -1,0 +1,11 @@
+package com.concepts_and_quizzes.cds.domain.analytics
+
+/**
+ * Represents performance for a topic on a particular day.
+ */
+data class TopicTrendPoint(
+    val topicId: String,
+    val day: String,
+    val total: Int,
+    val correct: Int
+)


### PR DESCRIPTION
## Summary
- add AttemptLog table for question attempts and indices for qid/time
- provide DAO and repository to compute topic stats, trends, difficulty and discrimination
- integrate analytics into Room database and Hilt module

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891809a22b08329985d04fffbacc591