### PR TITLE
Implement lifecycle-aware quiz timer

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -32,7 +32,7 @@ It is intended to be updated whenever new features are added or existing functio
 - `ui/english/concepts/ConceptDetailViewModel.kt` – Loads a single topic based on navigation arguments.
 - `ui/english/concepts/ConceptDetailScreen.kt` – Shows the selected topic’s name and overview.
 - `ui/english/pyqp/PyqpPaperListScreen.kt` – Lists available previous year papers.
-- `ui/english/pyqp/QuizScreen.kt` – Runs a quiz for a selected paper with timer, question flagging and a palette for quick navigation, showing section intro pages and collapsible headers for passages or directions.
+- `ui/english/pyqp/QuizScreen.kt` – Runs a quiz for a selected paper with a countdown timer (pause/resume on lifecycle events), question flagging and a palette for quick navigation, showing section intro pages and collapsible headers for passages or directions.
 - `ui/english/pyqp/PyqpListViewModel.kt`, `QuizViewModel.kt` – View models for paper list and quiz screens with paging and section intro logic.
 - `ui/english/quiz/QuizScreen.kt` – Placeholder quiz view for a topic.
 - `ui/english/analysis/AnalysisScreen.kt` – Placeholder analysis screen.


### PR DESCRIPTION
## Summary
- add ViewModel-driven countdown timer that pauses on background and resumes when returning
- display color-coded timer in quiz UI
- document new quiz screen timer behavior

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689192e69784832991ee5a28e5b0e6fe