### PR TITLE
Improve quiz timer lifecycle and accessibility

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalAccessibilityManager
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
@@ -65,13 +66,27 @@ private fun QuizPager(vm: QuizViewModel, state: QuizViewModel.QuizUi.Page) {
     DisposableEffect(lifecycle) {
         val obs = LifecycleEventObserver { _, e ->
             when (e) {
-                Lifecycle.Event.ON_START -> vm.resume()
+                Lifecycle.Event.ON_START,
+                Lifecycle.Event.ON_RESUME -> vm.resume()
                 Lifecycle.Event.ON_STOP -> vm.pause()
                 else -> Unit
             }
         }
         lifecycle.addObserver(obs)
         onDispose { lifecycle.removeObserver(obs) }
+    }
+    val accessibilityManager = LocalAccessibilityManager.current
+    var announcedTen by remember { mutableStateOf(false) }
+    var announcedFive by remember { mutableStateOf(false) }
+    LaunchedEffect(remaining) {
+        if (!announcedTen && remaining == 10 * 60) {
+            accessibilityManager?.announceForAccessibility("10 minutes remaining")
+            announcedTen = true
+        }
+        if (!announcedFive && remaining == 5 * 60) {
+            accessibilityManager?.announceForAccessibility("5 minutes remaining")
+            announcedFive = true
+        }
     }
     var showSubmit by remember { mutableStateOf(false) }
     var showPalette by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -9,6 +9,7 @@ import com.concepts_and_quizzes.cds.data.english.repo.PyqpRepository
 import com.concepts_and_quizzes.cds.domain.english.PyqpQuestion
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -105,12 +106,14 @@ class QuizViewModel @Inject constructor(
 
     private fun startTimer() {
         if (timerJob != null) return
-        timerJob = viewModelScope.launch {
+        timerJob = viewModelScope.launch(Dispatchers.Default) {
             while (_timer.value > 0) {
                 delay(1_000)
                 val next = _timer.value - 1
                 _timer.value = next
-                state["timerSec"] = next
+                if (next % 60 == 0) {
+                    state["timerSec"] = next
+                }
             }
             submit()
         }
@@ -119,6 +122,7 @@ class QuizViewModel @Inject constructor(
     fun pause() {
         timerJob?.cancel()
         timerJob = null
+        state["timerSec"] = _timer.value
     }
 
     fun resume() {


### PR DESCRIPTION
## Summary
- resume quiz timer when returning to the screen
- reduce saved timer updates and persist on pause
- announce time remaining for accessibility

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689196bad8d883299d386eb8ed3a13c3