### PR TITLE
Implement quiz duration flush, result state, palette legend

### DIFF
--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
@@ -86,7 +86,7 @@ class QuizViewModelTest {
         vm.next()
         advanceUntilIdle()
 
-        val res = vm.ui.value as QuizViewModel.QuizUi.Result
+        val res = vm.result.value!!
         assertEquals(2, res.correct)
         assertEquals(3, res.total)
         assertEquals(3, inserted.size)


### PR DESCRIPTION
## Summary
- Track question time with `SystemClock.elapsedRealtime` and flush on pause
- Persist and reset quiz result dialog visibility using `SavedStateHandle`
- Add legend chips to quiz palette for answered/flagged/unanswered states

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891a5f87c9883299fb166c0924b1235