### PR TITLE
Shuffle options and highlight selection

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
@@ -28,7 +28,7 @@ fun PyqpQuestionEntity.toDomain() = PyqpQuestion(
         AnswerOption(optionB, correctIndex == 1),
         AnswerOption(optionC, correctIndex == 2),
         AnswerOption(optionD, correctIndex == 3)
-    ),
+    ).shuffled(),
     direction = direction,
     passage = passageText,
     passageTitle = passageTitle

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/repo/PyqpRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/repo/PyqpRepository.kt
@@ -3,7 +3,6 @@ package com.concepts_and_quizzes.cds.data.english.repo
 import com.concepts_and_quizzes.cds.data.english.db.PyqpDao
 import com.concepts_and_quizzes.cds.data.english.model.toDomain
 import com.concepts_and_quizzes.cds.domain.english.PyqpQuestion
-import com.concepts_and_quizzes.cds.domain.english.shuffledOptions
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -17,7 +16,7 @@ class PyqpRepository @Inject constructor(
         }
 
     fun getQuestions(paperId: String): Flow<List<PyqpQuestion>> =
-        dao.getQuestionsByPaper(paperId).map { list -> list.map { it.toDomain().shuffledOptions() } }
+        dao.getQuestionsByPaper(paperId).map { list -> list.map { it.toDomain() } }
 }
 
 data class PyqpPaper(val id: String, val year: Int)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/PyqpQuestion.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/PyqpQuestion.kt
@@ -8,6 +8,3 @@ data class PyqpQuestion(
     val passage: String? = null,
     val passageTitle: String? = null
 )
-
-fun PyqpQuestion.shuffledOptions(): PyqpQuestion =
-    copy(options = options.shuffled())

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -3,6 +3,7 @@ package com.concepts_and_quizzes.cds.ui.english.pyqp
 import android.annotation.SuppressLint
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
@@ -298,6 +299,7 @@ private fun OptionCard(selected: Boolean, text: String, onClick: () -> Unit) {
             .fillMaxWidth()
             .padding(vertical = 4.dp),
         onClick = onClick,
+        border = if (selected) BorderStroke(2.dp, MaterialTheme.colorScheme.primary) else null,
         colors = CardDefaults.cardColors(
             containerColor = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface
         )


### PR DESCRIPTION
## Summary
- shuffle answer options when mapping to domain objects
- draw a primary border around selected answer options

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891a94295308329906ef91e58e8d29d