### PR TITLE
Snapshot quiz progress periodically

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -144,6 +144,9 @@ class QuizViewModel @Inject constructor(
                 if (next % 60 == 0) {
                     state["timerSec"] = next
                 }
+                if (next % 30 == 0) {
+                    resumeStore.save(QuizResumeStore.Store(paperId, snapshot()))
+                }
                 if (next == 0) {
                     submitQuiz()
                     break


### PR DESCRIPTION
## Summary
- Periodically persist quiz state (answers/flags) to `QuizResumeStore` every 30 seconds so progress can be resumed after process death

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892078dc7508329a3d5febeda6ff487