### PR TITLE
Shuffle options and persist quiz snapshot

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
@@ -2,8 +2,6 @@ package com.concepts_and_quizzes.cds.data.english.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.concepts_and_quizzes.cds.domain.english.AnswerOption
-import com.concepts_and_quizzes.cds.domain.english.PyqpQuestion
 
 @Entity(tableName = "pyqp_questions")
 data class PyqpQuestionEntity(
@@ -18,18 +16,4 @@ data class PyqpQuestionEntity(
     val direction: String? = null,
     val passageTitle: String? = null,
     val passageText: String? = null
-)
-
-fun PyqpQuestionEntity.toDomain() = PyqpQuestion(
-    id = qid,
-    text = question,
-    options = listOf(
-        AnswerOption(optionA, correctIndex == 0),
-        AnswerOption(optionB, correctIndex == 1),
-        AnswerOption(optionC, correctIndex == 2),
-        AnswerOption(optionD, correctIndex == 3)
-    ).shuffled(),
-    direction = direction,
-    passage = passageText,
-    passageTitle = passageTitle
 )

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/repo/PyqpRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/repo/PyqpRepository.kt
@@ -1,7 +1,7 @@
 package com.concepts_and_quizzes.cds.data.english.repo
 
 import com.concepts_and_quizzes.cds.data.english.db.PyqpDao
-import com.concepts_and_quizzes.cds.data.english.model.toDomain
+import com.concepts_and_quizzes.cds.domain.english.AnswerOption
 import com.concepts_and_quizzes.cds.domain.english.PyqpQuestion
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -16,7 +16,23 @@ class PyqpRepository @Inject constructor(
         }
 
     fun getQuestions(paperId: String): Flow<List<PyqpQuestion>> =
-        dao.getQuestionsByPaper(paperId).map { list -> list.map { it.toDomain() } }
+        dao.getQuestionsByPaper(paperId).map { list ->
+            list.map { e ->
+                PyqpQuestion(
+                    id = e.qid,
+                    text = e.question,
+                    options = listOf(
+                        AnswerOption(e.optionA, e.correctIndex == 0),
+                        AnswerOption(e.optionB, e.correctIndex == 1),
+                        AnswerOption(e.optionC, e.correctIndex == 2),
+                        AnswerOption(e.optionD, e.correctIndex == 3)
+                    ).shuffled(),
+                    direction = e.direction,
+                    passage = e.passageText,
+                    passageTitle = e.passageTitle
+                )
+            }
+        }
 }
 
 data class PyqpPaper(val id: String, val year: Int)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/quiz/QuizResumeStore.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/quiz/QuizResumeStore.kt
@@ -12,8 +12,17 @@ class QuizResumeStore @Inject constructor() {
     private val _store = MutableStateFlow<Store?>(null)
     val store: StateFlow<Store?> = _store
 
-    fun save(store: Store) {
-        _store.value = store
+    fun save(
+        paperId: String,
+        answers: Map<Int, Int>,
+        flags: Set<Int>,
+        pageIndex: Int,
+        remaining: Int,
+    ) {
+        val ans = answers.entries.joinToString(";") { "${it.key}:${it.value}" }
+        val flg = flags.joinToString(",")
+        val snapshot = listOf(pageIndex, ans, flg, remaining).joinToString("|")
+        _store.value = Store(paperId, snapshot)
     }
 
     fun restore(snapshot: String) {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -145,7 +145,7 @@ class QuizViewModel @Inject constructor(
                     state["timerSec"] = next
                 }
                 if (next % 30 == 0) {
-                    resumeStore.save(QuizResumeStore.Store(paperId, snapshot()))
+                    resumeStore.save(paperId, answers, flags, pageIndex, next)
                 }
                 if (next == 0) {
                     submitQuiz()
@@ -155,19 +155,12 @@ class QuizViewModel @Inject constructor(
         }
     }
 
-    private fun snapshot(): String {
-        val ans = answers.entries.joinToString(";") { "${it.key}:${it.value}" }
-        val flg = flags.joinToString(",")
-        val dur = durations.entries.joinToString(";") { "${it.key}:${it.value}" }
-        return listOf(pageIndex, ans, flg, dur, _timer.value).joinToString("|")
-    }
-
     fun pause() {
         flushDuration()
         timerJob?.cancel()
         timerJob = null
         state["timerSec"] = _timer.value
-        resumeStore.save(QuizResumeStore.Store(paperId, snapshot()))
+        resumeStore.save(paperId, answers, flags, pageIndex, _timer.value)
     }
 
     fun resume() {


### PR DESCRIPTION
## Summary
- shuffle quiz answer options when loading PYQP questions
- persist quiz progress snapshot with answers, flags, page, and time
- save snapshot on pause and periodic timer tick

## Testing
- `./gradlew test` *(fails: Android SDK packages missing and licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_689209a213e88329ab30363596536e52