### PR TITLE
Add PYQ analytics screen with topic stats

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
@@ -10,6 +10,7 @@ import com.concepts_and_quizzes.cds.ui.english.concepts.ConceptsHomeScreen
 import com.concepts_and_quizzes.cds.ui.english.dashboard.EnglishDashboardScreen
 import com.concepts_and_quizzes.cds.ui.english.quiz.QuizHubScreen
 import com.concepts_and_quizzes.cds.ui.english.pyqp.PyqpPaperListScreen
+import com.concepts_and_quizzes.cds.ui.english.pyqp.PyqAnalyticsScreen
 import com.concepts_and_quizzes.cds.ui.english.pyqp.QuizScreen as PyqpQuizScreen
 
 fun NavGraphBuilder.rootGraph(nav: NavHostController) {
@@ -21,6 +22,7 @@ fun NavGraphBuilder.rootGraph(nav: NavHostController) {
     }
     composable("quizHub") { QuizHubScreen(nav) }
     composable("english/pyqp") { PyqpPaperListScreen(nav) }
+    composable("analytics/pyq") { PyqAnalyticsScreen(nav) }
     composable(
         route = "english/pyqp/{paperId}",
         arguments = listOf(navArgument("paperId") { type = NavType.StringType })

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
@@ -14,21 +14,6 @@ interface AttemptLogDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(attempts: List<AttemptLogEntity>)
 
-    // --- Topic snapshot ---
-    @Query(
-        """
-        SELECT q.topicId AS topicId,
-               COUNT(*) AS total,
-               SUM(CASE WHEN a.correct THEN 1 ELSE 0 END) AS correct,
-               AVG(a.durationMs) AS avgDurationMs,
-               SUM(CASE WHEN a.flagged THEN 1 ELSE 0 END) AS flagged
-        FROM attempt_log a
-        JOIN english_questions q ON a.qid = q.qid
-        GROUP BY q.topicId
-        """
-    )
-    fun getTopicSnapshot(): Flow<List<TopicSnapshotDb>>
-
     // --- Trend over time ---
     @Query(
         """
@@ -84,14 +69,6 @@ interface AttemptLogDao {
 }
 
 // --- Data classes for query results ---
-
-data class TopicSnapshotDb(
-    val topicId: String,
-    val total: Int,
-    val correct: Int,
-    val avgDurationMs: Double,
-    val flagged: Int
-)
 
 data class TopicTrendPointDb(
     val topicId: String,

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/TopicStatDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/TopicStatDao.kt
@@ -1,0 +1,36 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import androidx.room.Dao
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Analytics queries for PYQ topic accuracy statistics.
+ */
+@Dao
+interface TopicStatDao {
+    @Query(
+        """
+        SELECT q.topic AS topic,
+               COUNT(*) AS total,
+               SUM(CASE WHEN a.correct THEN 1 ELSE 0 END) AS correct
+        FROM attempt_log AS a
+        JOIN pyqp_questions AS q ON q.qid = a.qid
+        WHERE a.timestamp >= :cutoffTime
+        GROUP BY q.topic
+        ORDER BY correct * 1.0 / total DESC
+        """
+    )
+    fun topicSnapshot(cutoffTime: Long): Flow<List<TopicStat>>
+}
+
+/**
+ * Aggregated stats for a single topic.
+ */
+data class TopicStat(
+    val topic: String,
+    val total: Int,
+    val correct: Int
+) {
+    val percent: Float get() = if (total == 0) 0f else correct * 100f / total
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabase.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabase.kt
@@ -16,7 +16,7 @@ import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
         PyqpProgress::class,
         AttemptLogEntity::class
     ],
-    version = 5
+    version = 6
 )
 abstract class EnglishDatabase : RoomDatabase() {
     abstract fun topicDao(): EnglishTopicDao
@@ -24,4 +24,5 @@ abstract class EnglishDatabase : RoomDatabase() {
     abstract fun pyqpDao(): PyqpDao
     abstract fun pyqpProgressDao(): PyqpProgressDao
     abstract fun attemptLogDao(): com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
+    abstract fun topicStatDao(): com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabaseModule.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabaseModule.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import com.concepts_and_quizzes.cds.data.english.repo.EnglishRepository
 import com.concepts_and_quizzes.cds.data.english.repo.PyqpRepository
 import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
+import com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao
 import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
 import dagger.Module
 import dagger.Provides
@@ -39,6 +40,9 @@ object EnglishDatabaseModule {
     fun provideAttemptLogDao(db: EnglishDatabase): AttemptLogDao = db.attemptLogDao()
 
     @Provides
+    fun provideTopicStatDao(db: EnglishDatabase): TopicStatDao = db.topicStatDao()
+
+    @Provides
     @Singleton
     fun provideEnglishRepository(
         topicDao: EnglishTopicDao,
@@ -51,6 +55,9 @@ object EnglishDatabaseModule {
 
     @Provides
     @Singleton
-    fun provideAnalyticsRepository(attemptDao: AttemptLogDao): AnalyticsRepository =
-        AnalyticsRepository(attemptDao)
+    fun provideAnalyticsRepository(
+        attemptDao: AttemptLogDao,
+        topicStatDao: TopicStatDao
+    ): AnalyticsRepository =
+        AnalyticsRepository(attemptDao, topicStatDao)
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/SeedUtil.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/SeedUtil.kt
@@ -99,7 +99,9 @@ class SeedUtil @Inject constructor(
                         correctIndex = correct,
                         direction = dirText,
                         passageTitle = passage?.first,
-                        passageText = passage?.second
+                        passageText = passage?.second,
+                        topic = q.optString("topic"),
+                        subTopic = q.optString("sub_topic")
                     )
                 )
             }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/PyqpQuestionEntity.kt
@@ -15,5 +15,7 @@ data class PyqpQuestionEntity(
     val correctIndex: Int,
     val direction: String? = null,
     val passageTitle: String? = null,
-    val passageText: String? = null
+    val passageText: String? = null,
+    val topic: String = "",
+    val subTopic: String = ""
 )

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -21,7 +21,7 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
         CdsCard {
             Column(
                 Modifier
-                    .clickable { nav.navigate("english/pyqp") }
+                    .clickable { nav.navigate("analytics/pyq") }
                     .padding(16.dp)
             ) {
                 Text("PYQ Summary")

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
@@ -1,0 +1,101 @@
+package com.concepts_and_quizzes.cds.ui.english.pyqp
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.FilterChip
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.concepts_and_quizzes.cds.data.analytics.db.TopicStat
+import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
+
+@Composable
+fun PyqAnalyticsScreen(
+    nav: NavController,
+    vm: PyqAnalyticsViewModel = hiltViewModel()
+) {
+    val window by vm.window.collectAsState()
+    val stats by vm.stats.collectAsState()
+
+    Scaffold(topBar = { TopAppBar(title = { Text("PYQ Analytics") }) }) { pad ->
+        Column(Modifier.padding(pad).padding(16.dp)) {
+            FilterChipRow(window) { vm.setWindow(it) }
+
+            Spacer(Modifier.height(16.dp))
+
+            if (stats.isEmpty()) {
+                Text("Attempt a PYQ to unlock analytics.")
+                return@Column
+            }
+
+            TopicBarList(stats)
+
+            Spacer(Modifier.height(24.dp))
+
+            vm.weakestTopic()?.let { weak ->
+                Button(onClick = {
+                    nav.navigate("english/pyqp/revision?topic=${weak.topic}")
+                }) {
+                    Text("Retake weakest topic (${weak.topic})")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterChipRow(
+    selected: AnalyticsRepository.Window,
+    onSelect: (AnalyticsRepository.Window) -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        AnalyticsRepository.Window.values().forEach { w ->
+            FilterChip(
+                selected = w == selected,
+                onClick = { onSelect(w) },
+                label = {
+                    Text(
+                        when (w) {
+                            AnalyticsRepository.Window.LAST_7 -> "7 days"
+                            AnalyticsRepository.Window.LAST_30 -> "30 days"
+                            AnalyticsRepository.Window.LIFETIME -> "All time"
+                        }
+                    )
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun TopicBarList(stats: List<TopicStat>) {
+    val max = stats.maxOf { it.percent }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        stats.take(10).forEach { s ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(s.topic, Modifier.width(120.dp))
+                Canvas(Modifier.weight(1f).height(16.dp)) {
+                    val frac = if (max == 0f) 0f else s.percent / max
+                    drawRect(
+                        color = MaterialTheme.colorScheme.primary,
+                        size = Size(size.width * frac, size.height)
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                val pct = "%.0f".format(s.percent)
+                Text("$pct %")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsViewModel.kt
@@ -1,0 +1,29 @@
+package com.concepts_and_quizzes.cds.ui.english.pyqp
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.concepts_and_quizzes.cds.data.analytics.db.TopicStat
+import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.SharingStarted
+
+@HiltViewModel
+class PyqAnalyticsViewModel @Inject constructor(
+    private val repo: AnalyticsRepository
+) : ViewModel() {
+
+    private val _window = MutableStateFlow(AnalyticsRepository.Window.LAST_30)
+    val window: StateFlow<AnalyticsRepository.Window> = _window
+
+    val stats: StateFlow<List<TopicStat>> =
+        _window.flatMapLatest { repo.topicSnapshot(it) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
+
+    fun setWindow(w: AnalyticsRepository.Window) { _window.value = w }
+    fun weakestTopic(): TopicStat? = stats.value.minByOrNull { it.percent }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -75,7 +75,7 @@ fun QuizScreen(
 
     if (showResult) {
         result?.let { r ->
-            ResultView(r) {
+            ResultView(r, nav) {
                 vm.saveProgress()
                 vm.dismissResult()
                 nav.popBackStack()
@@ -392,11 +392,26 @@ private fun LegendChip(color: Color, label: String) {
 }
 
 @Composable
-private fun ResultView(r: QuizViewModel.QuizResult, onClose: () -> Unit) {
+private fun ResultView(
+    r: QuizViewModel.QuizResult,
+    nav: NavController,
+    onClose: () -> Unit
+) {
     AlertDialog(
         onDismissRequest = onClose,
         confirmButton = { TextButton(onClick = onClose) { Text("Done") } },
         title = { Text("Result") },
-        text = { Text("Score: ${r.correct}/${r.total}") }
+        text = {
+            Column {
+                Text("Score: ${r.correct}/${r.total}")
+                Spacer(Modifier.height(12.dp))
+                Button(onClick = {
+                    onClose()
+                    nav.navigate("analytics/pyq")
+                }) {
+                    Text("View analytics")
+                }
+            }
+        }
     )
 }

--- a/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/db/TopicStatDaoTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/db/TopicStatDaoTest.kt
@@ -1,0 +1,58 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.concepts_and_quizzes.cds.data.english.db.EnglishDatabase
+import com.concepts_and_quizzes.cds.data.english.model.PyqpQuestionEntity
+import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TopicStatDaoTest {
+    private lateinit var db: EnglishDatabase
+    private lateinit var dao: TopicStatDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, EnglishDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.topicStatDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun topicSnapshot_countsCorrectly() = runTest {
+        val questions = listOf(
+            PyqpQuestionEntity("Q1", "Paper", "q1", "a", "b", "c", "d", 0, topic = "Grammar", subTopic = "X"),
+            PyqpQuestionEntity("Q2", "Paper", "q2", "a", "b", "c", "d", 1, topic = "Grammar", subTopic = "X"),
+            PyqpQuestionEntity("Q3", "Paper", "q3", "a", "b", "c", "d", 2, topic = "Vocab", subTopic = "Y")
+        )
+        db.pyqpDao().insertAll(questions)
+        val now = System.currentTimeMillis()
+        db.attemptLogDao().insertAll(
+            listOf(
+                AttemptLogEntity(qid = "Q1", quizId = "Paper", correct = true, flagged = false, durationMs = 1000, timestamp = now),
+                AttemptLogEntity(qid = "Q2", quizId = "Paper", correct = false, flagged = false, durationMs = 1000, timestamp = now),
+                AttemptLogEntity(qid = "Q3", quizId = "Paper", correct = true, flagged = false, durationMs = 1000, timestamp = now)
+            )
+        )
+        val stats = dao.topicSnapshot(0L).first()
+        val grammar = stats.first { it.topic == "Grammar" }
+        assertEquals(2, grammar.total)
+        assertEquals(1, grammar.correct)
+    }
+}

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
 import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicDifficultyDb
-import com.concepts_and_quizzes.cds.data.analytics.db.TopicSnapshotDb
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicTrendPointDb
 import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
 import com.concepts_and_quizzes.cds.data.english.db.PyqpDao
@@ -60,12 +59,14 @@ class QuizViewModelTest {
             override suspend fun insertAll(attempts: List<AttemptLogEntity>) {
                 inserted.addAll(attempts)
             }
-            override fun getTopicSnapshot(): Flow<List<TopicSnapshotDb>> = flowOf(emptyList())
             override fun getTrend(startTime: Long): Flow<List<TopicTrendPointDb>> = flowOf(emptyList())
             override fun getDifficulty(): Flow<List<TopicDifficultyDb>> = flowOf(emptyList())
             override fun getAttemptsWithScore(): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptWithScoreDb>> = flowOf(emptyList())
         }
-        val analytics = AnalyticsRepository(attemptDao)
+        val topicStatDao = object : com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao {
+            override fun topicSnapshot(cutoffTime: Long): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.TopicStat>> = flowOf(emptyList())
+        }
+        val analytics = AnalyticsRepository(attemptDao, topicStatDao)
         val vm = QuizViewModel(repo, progressDao, analytics, SavedStateHandle(mapOf("paperId" to "paper")))
         advanceUntilIdle()
 


### PR DESCRIPTION
## Summary
- track PYQ question topics for analytics and seed them from JSON
- expose windowed topic snapshots and render a PYQ analytics screen with filter chips and bar chart
- navigate to analytics from dashboard and quiz results, with unit test for topic stats query

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689210180ee8832985ce5e7de2d1e347