### PR TITLE
Fix composable usage in PYQ analytics screen

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
@@ -45,7 +45,8 @@ fun PyqAnalyticsScreen(
 
             Spacer(Modifier.height(24.dp))
 
-            vm.weakestTopic()?.let { weak ->
+            val weak = vm.weakestTopic()
+            if (weak != null) {
                 Button(onClick = {
                     nav.navigate("english/pyqp/revision?topic=${weak.topic}")
                 }) {


### PR DESCRIPTION
## Summary
- avoid calling Button inside non-composable let block in PyqAnalyticsScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689214ba57d0832989ee950603e4a23e