### PR TITLE
Improve PYQ analytics sorting and cutoff

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/TopicStatDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/TopicStatDao.kt
@@ -13,12 +13,12 @@ interface TopicStatDao {
         """
         SELECT q.topic AS topic,
                COUNT(*) AS total,
-               SUM(CASE WHEN a.correct THEN 1 ELSE 0 END) AS correct
+               SUM(a.correct) AS correct
         FROM attempt_log AS a
         JOIN pyqp_questions AS q ON q.qid = a.qid
         WHERE a.timestamp >= :cutoffTime
         GROUP BY q.topic
-        ORDER BY correct * 1.0 / total DESC
+        ORDER BY (SUM(a.correct) * 1.0 / COUNT(*)) DESC
         """
     )
     fun topicSnapshot(cutoffTime: Long): Flow<List<TopicStat>>

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/AnalyticsRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/AnalyticsRepository.kt
@@ -7,6 +7,9 @@ import com.concepts_and_quizzes.cds.data.analytics.db.TopicStat as PyqTopicStat
 import com.concepts_and_quizzes.cds.domain.analytics.QuestionDiscrimination
 import com.concepts_and_quizzes.cds.domain.analytics.TopicDifficulty
 import com.concepts_and_quizzes.cds.domain.analytics.TopicTrendPoint
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import javax.inject.Inject
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -29,7 +32,13 @@ class AnalyticsRepository @Inject constructor(
         LAST_7(7), LAST_30(30), LIFETIME(null);
 
         fun cutoff(now: Long = System.currentTimeMillis()): Long =
-            days?.let { now - it * 86_400_000L } ?: 0L
+            days?.let {
+                Instant.ofEpochMilli(now).atZone(ZoneId.systemDefault()).toLocalDate()
+                    .minusDays(it.toLong())
+                    .atStartOfDay(ZoneId.systemDefault())
+                    .toInstant()
+                    .toEpochMilli()
+            } ?: 0L
     }
 
     fun topicSnapshot(window: Window): Flow<List<PyqTopicStat>> =

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
@@ -48,7 +48,7 @@ fun PyqAnalyticsScreen(
             val weak = vm.weakestTopic()
             if (weak != null) {
                 Button(onClick = {
-                    nav.navigate("english/pyqp/revision?topic=${weak.topic}")
+                    nav.navigate("english/pyqp?mode=WRONGS&topic=${weak.topic}")
                 }) {
                     Text("Retake weakest topic (${weak.topic})")
                 }
@@ -91,7 +91,7 @@ private fun TopicBarList(stats: List<TopicStat>) {
                 Canvas(Modifier.weight(1f).height(16.dp)) {
                     val frac = if (max == 0f) 0f else s.percent / max
                     drawRect(
-                        color = MaterialTheme.colorScheme.primary,
+                        color = MaterialTheme.colorScheme.tertiary,
                         size = Size(size.width * frac, size.height)
                     )
                 }


### PR DESCRIPTION
## Summary
- Correctly order PYQ topic stats by computing ratio directly in SQL and summing booleans
- Use DST-safe window cutoff using java.time APIs
- Update analytics CTA to launch wrong-only quiz and use higher contrast bar color

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689214078d1883299469f6606204de11