### PR TITLE
Fix composable usage in PYQ analytics screen

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
@@ -38,18 +38,18 @@ fun PyqAnalyticsScreen(
 
             if (stats.isEmpty()) {
                 Text("Attempt a PYQ to unlock analytics.")
-                return@Column
-            }
+            } else {
+                TopicBarList(stats)
 
-            TopicBarList(stats)
+                Spacer(Modifier.height(24.dp))
 
-            Spacer(Modifier.height(24.dp))
-
-            vm.weakestTopic()?.let { weak ->
-                Button(onClick = {
-                    nav.navigate("english/pyqp/revision?topic=${weak.topic}")
-                }) {
-                    Text("Retake weakest topic (${weak.topic})")
+                val weak = vm.weakestTopic()
+                if (weak != null) {
+                    Button(onClick = {
+                        nav.navigate("english/pyqp/revision?topic=${weak.topic}")
+                    }) {
+                        Text("Retake weakest topic (${weak.topic})")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- avoid calling Button inside non-composable let block in PyqAnalyticsScreen
- guard analytics components so they render only when stats are available

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689214ba57d0832989ee950603e4a23e