### PR TITLE
Refine quiz hub navigation and bottom bar visibility

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -34,6 +34,7 @@ It is intended to be updated whenever new features are added or existing functio
 - `ui/english/pyqp/PyqpPaperListScreen.kt` – Lists available previous year papers.
 - `ui/english/pyqp/QuizScreen.kt` – Runs a quiz for a selected paper with a countdown timer (pause/resume on lifecycle events), question flagging and a palette for quick navigation, showing section intro pages and collapsible headers for passages or directions.
 - `ui/english/pyqp/PyqpListViewModel.kt`, `QuizViewModel.kt` – View models for paper list and quiz screens with paging and section intro logic.
+- `ui/english/quiz/QuizHubScreen.kt`, `QuizHubViewModel.kt` – Hub for starting or resuming previous year question practice and accessing analytics.
 - `ui/english/quiz/QuizScreen.kt` – Placeholder quiz view for a topic.
 - `ui/english/analysis/AnalysisScreen.kt` – Placeholder analysis screen.
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
@@ -32,7 +32,14 @@ private fun CDSApp() {
         val navController = rememberNavController()
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route
-        val showBottomBar = currentRoute != null
+        val bottomBarRoutes = setOf(
+            "english/dashboard",
+            "english/concepts",
+            "quizHub",
+            "english/pyqp?mode={mode}&topic={topic}",
+            "analytics/pyq"
+        )
+        val showBottomBar = currentRoute in bottomBarRoutes
 
         Scaffold(bottomBar = { if (showBottomBar) CdsBottomNavBar(navController) }) { padding ->
             NavHost(

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/components/BottomNavBar.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/components/BottomNavBar.kt
@@ -27,8 +27,16 @@ fun CdsBottomNavBar(navController: NavHostController) {
         val navBackStackEntry = navController.currentBackStackEntryAsState().value
         val currentRoute = navBackStackEntry?.destination?.route
         items.forEach { item ->
+            val selected = when (item.route) {
+                "english/dashboard" -> currentRoute == "english/dashboard"
+                "english/concepts" -> currentRoute?.startsWith("english/concepts") == true
+                "quizHub" -> currentRoute == "quizHub" ||
+                    currentRoute?.startsWith("english/pyqp") == true ||
+                    currentRoute == "analytics/pyq"
+                else -> false
+            }
             NavigationBarItem(
-                selected = currentRoute == item.route,
+                selected = selected,
                 onClick = {
                     navController.navigate(item.route) {
                         popUpTo(navController.graph.findStartDestination().id) {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
@@ -1,6 +1,7 @@
 package com.concepts_and_quizzes.cds.ui.english.quiz
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
@@ -16,8 +17,17 @@ import com.concepts_and_quizzes.cds.core.components.CdsCard
 @Composable
 fun QuizHubScreen(nav: NavHostController, vm: QuizHubViewModel = hiltViewModel()) {
     val store by vm.store.collectAsState()
-    Column(Modifier.padding(16.dp)) {
+    Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         Text("Quiz Hub")
+        CdsCard {
+            Column(
+                Modifier
+                    .clickable { nav.navigate("english/pyqp") }
+                    .padding(16.dp)
+            ) {
+                Text("Start PYQ")
+            }
+        }
         store?.let { s ->
             CdsCard {
                 Column(
@@ -32,6 +42,15 @@ fun QuizHubScreen(nav: NavHostController, vm: QuizHubViewModel = hiltViewModel()
                 ) {
                     Text("Resume PYQ")
                 }
+            }
+        }
+        CdsCard {
+            Column(
+                Modifier
+                    .clickable { nav.navigate("analytics/pyq") }
+                    .padding(16.dp)
+            ) {
+                Text("Analytics")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Hide bottom navigation on non-root destinations and highlight active sections correctly
- Add start, resume, and analytics entry points to quiz hub
- Document quiz hub components in codebase overview

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892217b7150832997dadfa6b2a4eeb8