### PR TITLE
Persist question durations across pauses

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/quiz/QuizResumeStore.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/quiz/QuizResumeStore.kt
@@ -18,10 +18,12 @@ class QuizResumeStore @Inject constructor() {
         flags: Set<Int>,
         pageIndex: Int,
         remaining: Int,
+        durations: Map<Int, Int> = emptyMap(),
     ) {
         val ans = answers.entries.joinToString(";") { "${it.key}:${it.value}" }
         val flg = flags.joinToString(",")
-        val snapshot = listOf(pageIndex, ans, flg, remaining).joinToString("|")
+        val dur = durations.entries.joinToString(";") { "${it.key}:${it.value}" }
+        val snapshot = listOf(pageIndex, ans, flg, remaining, dur).joinToString("|")
         _store.value = Store(paperId, snapshot)
     }
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -169,7 +169,7 @@ class QuizViewModel @Inject constructor(
                     state["timerSec"] = next
                 }
                 if (next % 30 == 0) {
-                    resumeStore.save(quizId, answers, flags, pageIndex, next)
+                    resumeStore.save(quizId, answers, flags, pageIndex, next, durations)
                 }
                 if (next == 0) {
                     submitQuiz()
@@ -184,7 +184,7 @@ class QuizViewModel @Inject constructor(
         timerJob?.cancel()
         timerJob = null
         state["timerSec"] = _timer.value
-        resumeStore.save(quizId, answers, flags, pageIndex, _timer.value)
+        resumeStore.save(quizId, answers, flags, pageIndex, _timer.value, durations)
     }
 
     fun resume() {
@@ -220,6 +220,19 @@ class QuizViewModel @Inject constructor(
         val remaining = parts[3].toIntOrNull() ?: 0
         _timer.value = remaining
         state["timerSec"] = remaining
+        durations.clear()
+        if (parts.size >= 5 && parts[4].isNotBlank()) {
+            parts[4].split(";").forEach { entry ->
+                val kv = entry.split(":")
+                if (kv.size == 2) {
+                    val q = kv[0].toIntOrNull()
+                    val d = kv[1].toIntOrNull()
+                    if (q != null && d != null) {
+                        durations[q] = d
+                    }
+                }
+            }
+        }
         submitted = false
         _result.value = null
         _showResult.value = false

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
@@ -159,7 +159,7 @@ class QuizViewModelTest {
         val analytics = AnalyticsRepository(attemptDao, topicStatDao)
         val repo = PyqpRepository(dao, attemptDao)
         val resumeStore = QuizResumeStore()
-        resumeStore.save("paper", mapOf(1 to 2), setOf(1), 1, 0)
+        resumeStore.save("paper", mapOf(1 to 2), setOf(1), 1, 0, mapOf(1 to 500))
         val vm = QuizViewModel(repo, progressDao, analytics, resumeStore, SavedStateHandle(mapOf("paperId" to "paper")))
         advanceUntilIdle()
         val ui = vm.ui.value as QuizViewModel.QuizUi.Page


### PR DESCRIPTION
## Summary
- Persist question durations in QuizResumeStore snapshots
- Restore saved durations when resuming a quiz
- Update tests for new resume store snapshot format

## Testing
- `./gradlew test` *(fails: Could not determine dependencies / SDK license not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_6892e10f7b148329b40ad29bd5b3276f