### PR TITLE
Add high-contrast analytics and option haptic feedback

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -27,8 +27,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -317,11 +319,15 @@ private fun IntroPage(intro: QuizViewModel.QuizPage.Intro) {
 
 @Composable
 private fun OptionCard(selected: Boolean, text: String, onClick: () -> Unit) {
+    val haptic = LocalHapticFeedback.current
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
-        onClick = onClick,
+        onClick = {
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            onClick()
+        },
         border = if (selected) BorderStroke(2.dp, MaterialTheme.colorScheme.primary) else null,
         colors = CardDefaults.cardColors(
             containerColor = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface


### PR DESCRIPTION
## Summary
- add High contrast switch to analytics and render monochrome bars with stripe pattern for accessibility
- provide haptic feedback when selecting quiz options

## Testing
- `./gradlew test` *(fails: SDK location not found; attempted android-sdk install but ca-certificates-java error)*

------
https://chatgpt.com/codex/tasks/task_e_6892e51f00f08329aa2e9d740bf1c8ef