### PR TITLE
Fix retake spinner by querying latest wrong questions per topic

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
@@ -18,13 +18,12 @@ interface AttemptLogDao {
         """
         SELECT a.qid
         FROM attempt_log a
-        JOIN english_questions q ON a.qid = q.qid
-        WHERE q.topicId = :topicId
+        JOIN pyqp_questions q ON a.qid = q.qid
+        WHERE q.topic = :topicId
           AND a.timestamp = (
               SELECT MAX(a2.timestamp)
               FROM attempt_log a2
-              JOIN english_questions q2 ON a2.qid = q2.qid
-              WHERE q2.topicId = :topicId
+              WHERE a2.qid = a.qid
           )
           AND a.correct = 0
         """

--- a/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDaoTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDaoTest.kt
@@ -1,0 +1,56 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.concepts_and_quizzes.cds.data.english.db.EnglishDatabase
+import com.concepts_and_quizzes.cds.data.english.model.PyqpQuestionEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AttemptLogDaoTest {
+    private lateinit var db: EnglishDatabase
+    private lateinit var dao: AttemptLogDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, EnglishDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.attemptLogDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun latestWrongQids_returnsLatestWrongAttempts() = runTest {
+        val questions = listOf(
+            PyqpQuestionEntity("Q1", "P", "q1", "a", "b", "c", "d", 0, topic = "Grammar"),
+            PyqpQuestionEntity("Q2", "P", "q2", "a", "b", "c", "d", 1, topic = "Grammar"),
+            PyqpQuestionEntity("Q3", "P", "q3", "a", "b", "c", "d", 2, topic = "Grammar")
+        )
+        db.pyqpDao().insertAll(questions)
+        val now = System.currentTimeMillis()
+        dao.insertAll(
+            listOf(
+                AttemptLogEntity(qid = "Q1", quizId = "Quiz1", correct = false, flagged = false, durationMs = 100, timestamp = now),
+                AttemptLogEntity(qid = "Q1", quizId = "Quiz2", correct = true, flagged = false, durationMs = 100, timestamp = now + 1000),
+                AttemptLogEntity(qid = "Q2", quizId = "Quiz1", correct = false, flagged = false, durationMs = 100, timestamp = now + 500),
+                AttemptLogEntity(qid = "Q3", quizId = "Quiz1", correct = true, flagged = false, durationMs = 100, timestamp = now + 700)
+            )
+        )
+        val result = dao.latestWrongQids("Grammar")
+        assertEquals(listOf("Q2"), result)
+    }
+}
+


### PR DESCRIPTION
## Summary
- fix `latestWrongQids` query to pull latest wrong attempts for each PYQ question
- add unit test covering latest wrong attempt filtering

## Testing
- `./gradlew test` *(fails: Failed to install Android SDK packages: build-tools;35.0.0, platforms;android-36)*

------
https://chatgpt.com/codex/tasks/task_e_6892e865334c8329bc69c64ed68d748b