### PR TITLE
Add weekly trend analytics and sparkline chart

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/AnalyticsRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/AnalyticsRepository.kt
@@ -4,6 +4,7 @@ import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
 import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicStat as PyqTopicStat
+import com.concepts_and_quizzes.cds.data.analytics.db.TrendPoint
 import com.concepts_and_quizzes.cds.domain.analytics.QuestionDiscrimination
 import com.concepts_and_quizzes.cds.domain.analytics.TopicDifficulty
 import com.concepts_and_quizzes.cds.domain.analytics.TopicTrendPoint
@@ -43,6 +44,11 @@ class AnalyticsRepository @Inject constructor(
 
     fun topicSnapshot(window: Window): Flow<List<PyqTopicStat>> =
         topicStatDao.topicSnapshot(window.cutoff())
+            .flowOn(Dispatchers.IO)
+
+    fun trendSnapshot(window: Window): Flow<List<TrendPoint>> =
+        topicStatDao.trendSnapshot(window.cutoff())
+            .map { it.reversed() }
             .flowOn(Dispatchers.IO)
 
     fun getTrend(periodDays: Int = 30): Flow<List<TopicTrendPoint>> {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
@@ -1,7 +1,10 @@
 package com.concepts_and_quizzes.cds.ui.english.pyqp
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -9,13 +12,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicStat
+import com.concepts_and_quizzes.cds.data.analytics.db.TrendPoint
 import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -25,6 +36,8 @@ fun PyqAnalyticsScreen(
 ) {
     val window by vm.window.collectAsState()
     val stats by vm.stats.collectAsState()
+    val trend by vm.trend.collectAsState()
+    val tab by vm.tab.collectAsState()
     var highContrast by remember { mutableStateOf(false) }
 
     Scaffold(topBar = { TopAppBar(title = { Text("PYQ Analytics") }) }) { pad ->
@@ -39,21 +52,43 @@ fun PyqAnalyticsScreen(
 
             Spacer(Modifier.height(16.dp))
 
-            if (stats.isEmpty()) {
-                Text("Attempt a PYQ to unlock analytics.")
-                return@Column
+            TabRow(selectedTabIndex = tab.ordinal) {
+                Tab(
+                    text = { Text("Overview") },
+                    selected = tab == PyqAnalyticsViewModel.Tab.OVERVIEW,
+                    onClick = { vm.setTab(PyqAnalyticsViewModel.Tab.OVERVIEW) }
+                )
+                Tab(
+                    text = { Text("Trend") },
+                    selected = tab == PyqAnalyticsViewModel.Tab.TREND,
+                    onClick = { vm.setTab(PyqAnalyticsViewModel.Tab.TREND) }
+                )
             }
 
-            TopicBarList(stats, highContrast)
+            Spacer(Modifier.height(16.dp))
 
-            Spacer(Modifier.height(24.dp))
+            when (tab) {
+                PyqAnalyticsViewModel.Tab.OVERVIEW -> {
+                    if (stats.isEmpty()) {
+                        Text("Attempt a PYQ to unlock analytics.")
+                    } else {
+                        TopicBarList(stats, highContrast)
 
-            val weak = vm.weakestTopic()
-            if (weak != null) {
-                Button(onClick = {
-                    nav.navigate("english/pyqp?mode=WRONGS&topic=${weak.topic}")
-                }) {
-                    Text("Retake weakest topic (${weak.topic})")
+                        Spacer(Modifier.height(24.dp))
+
+                        val weak = vm.weakestTopic()
+                        if (weak != null) {
+                            Button(onClick = {
+                                nav.navigate("english/pyqp?mode=WRONGS&topic=${weak.topic}")
+                            }) {
+                                Text("Retake weakest topic (${weak.topic})")
+                            }
+                        }
+                    }
+                }
+
+                PyqAnalyticsViewModel.Tab.TREND -> {
+                    TrendTab(trend, highContrast)
                 }
             }
         }
@@ -122,6 +157,61 @@ private fun TopicBarList(stats: List<TopicStat>, highContrast: Boolean) {
                 Spacer(Modifier.width(8.dp))
                 Text("$pct %", color = content)
             }
+        }
+    }
+}
+
+@Composable
+private fun TrendTab(points: List<TrendPoint>, highContrast: Boolean) {
+    if (points.isEmpty()) {
+        Text("Attempt at least one paper to see your trend.", Modifier.padding(24.dp))
+        return
+    }
+
+    SparkLineChart(points, highContrast)
+    Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+        points.forEach {
+            val pct = "%.0f".format(it.percent)
+            Text(pct, style = MaterialTheme.typography.labelSmall)
+        }
+    }
+}
+
+@Composable
+private fun SparkLineChart(points: List<TrendPoint>, highContrast: Boolean) {
+    val max = points.maxOf { it.percent }
+    val anim = remember { Animatable(0f) }
+    LaunchedEffect(points) { anim.animateTo(1f, tween(600)) }
+
+    val desc = points.joinToString {
+        val pct = "%.0f".format(it.percent)
+        val week = Instant.ofEpochMilli(it.weekStart).atZone(ZoneId.systemDefault()).toLocalDate()
+        "$week : $pct percent"
+    }
+
+    val baseColor = if (highContrast) Color.Black else MaterialTheme.colorScheme.primary
+    val effect = if (highContrast) PathEffect.dashPathEffect(floatArrayOf(10f, 10f)) else null
+
+    Canvas(
+        Modifier
+            .fillMaxWidth()
+            .height(120.dp)
+            .padding(8.dp)
+            .semantics { contentDescription = desc }
+    ) {
+        val stepX = if (points.size == 1) 0f else size.width / (points.size - 1)
+        val path = Path()
+        points.forEachIndexed { i, p ->
+            val x = i * stepX
+            val y = size.height * (1 - p.percent / max.coerceAtLeast(1f))
+            if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        clipRect(right = size.width * anim.value) {
+            drawPath(
+                path = path,
+                color = baseColor,
+                style = Stroke(width = 4.dp.toPx(), pathEffect = effect)
+            )
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsViewModel.kt
@@ -3,6 +3,7 @@ package com.concepts_and_quizzes.cds.ui.english.pyqp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicStat
+import com.concepts_and_quizzes.cds.data.analytics.db.TrendPoint
 import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -20,10 +21,20 @@ class PyqAnalyticsViewModel @Inject constructor(
     private val _window = MutableStateFlow(AnalyticsRepository.Window.LAST_30)
     val window: StateFlow<AnalyticsRepository.Window> = _window
 
+    private val _tab = MutableStateFlow(Tab.OVERVIEW)
+    val tab: StateFlow<Tab> = _tab
+
     val stats: StateFlow<List<TopicStat>> =
         _window.flatMapLatest { repo.topicSnapshot(it) }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
+    val trend: StateFlow<List<TrendPoint>> =
+        _window.flatMapLatest { repo.trendSnapshot(it) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
+
     fun setWindow(w: AnalyticsRepository.Window) { _window.value = w }
+    fun setTab(t: Tab) { _tab.value = t }
     fun weakestTopic(): TopicStat? = stats.value.minByOrNull { it.percent }
+
+    enum class Tab { OVERVIEW, TREND }
 }

--- a/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/db/TrendSnapshotDaoTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/db/TrendSnapshotDaoTest.kt
@@ -1,0 +1,57 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.concepts_and_quizzes.cds.data.english.db.EnglishDatabase
+import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.LocalDate
+import java.time.ZoneId
+
+@RunWith(RobolectricTestRunner::class)
+class TrendSnapshotDaoTest {
+    private lateinit var db: EnglishDatabase
+    private lateinit var dao: TopicStatDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, EnglishDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.topicStatDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun trendSnapshot_limitsAndOrders() = runTest {
+        val base = LocalDate.of(2025, 1, 6) // Monday
+        val attempts = mutableListOf<AttemptLogEntity>()
+        for (w in 0 until 12) {
+            val ts = base.plusWeeks(w.toLong()).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            attempts += AttemptLogEntity(qid = "Q${w}a", quizId = "CDS$w", correct = true, flagged = false, durationMs = 0, timestamp = ts)
+            attempts += AttemptLogEntity(qid = "Q${w}b", quizId = "CDS$w", correct = false, flagged = false, durationMs = 0, timestamp = ts + 1)
+        }
+        db.attemptLogDao().insertAll(attempts)
+
+        val points = dao.trendSnapshot(0L).first()
+        assertEquals(10, points.size)
+        for (i in 1 until points.size) {
+            assertTrue(points[i - 1].weekStart > points[i].weekStart)
+        }
+        assertEquals(50f, points.first().percent)
+    }
+}

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
@@ -6,6 +6,7 @@ import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicDifficultyDb
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicTrendPointDb
 import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
+import com.concepts_and_quizzes.cds.data.analytics.db.TrendPoint
 import com.concepts_and_quizzes.cds.data.english.db.PyqpDao
 import com.concepts_and_quizzes.cds.data.english.db.PyqpProgressDao
 import com.concepts_and_quizzes.cds.data.english.model.PyqpProgress
@@ -24,7 +25,10 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class QuizViewModelTest {
     private val questions = listOf(
         PyqpQuestionEntity("q1", "paper", "q1", "a", "b", "c", "d", 0),
@@ -67,6 +71,7 @@ class QuizViewModelTest {
         }
         val topicStatDao = object : com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao {
             override fun topicSnapshot(cutoffTime: Long): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.TopicStat>> = flowOf(emptyList())
+            override fun trendSnapshot(cutoffTime: Long): Flow<List<TrendPoint>> = flowOf(emptyList())
         }
         val analytics = AnalyticsRepository(attemptDao, topicStatDao)
         val repo = PyqpRepository(dao, attemptDao)
@@ -119,6 +124,7 @@ class QuizViewModelTest {
         }
         val topicStatDao = object : com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao {
             override fun topicSnapshot(cutoffTime: Long): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.TopicStat>> = flowOf(emptyList())
+            override fun trendSnapshot(cutoffTime: Long): Flow<List<TrendPoint>> = flowOf(emptyList())
         }
         val analytics = AnalyticsRepository(attemptDao, topicStatDao)
         val repo = PyqpRepository(dao, attemptDao)
@@ -155,6 +161,7 @@ class QuizViewModelTest {
         }
         val topicStatDao = object : com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao {
             override fun topicSnapshot(cutoffTime: Long): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.TopicStat>> = flowOf(emptyList())
+            override fun trendSnapshot(cutoffTime: Long): Flow<List<TrendPoint>> = flowOf(emptyList())
         }
         val analytics = AnalyticsRepository(attemptDao, topicStatDao)
         val repo = PyqpRepository(dao, attemptDao)


### PR DESCRIPTION
## Summary
- aggregate attempt_log by week and expose TrendPoint through repository
- show sparkline chart on new Trend tab in PYQ analytics with tab navigation
- unit test weekly trend query

## Testing
- `./gradlew test` *(fails: 6 tests failed)*


------
https://chatgpt.com/codex/tasks/task_e_6892eb8e7f908329a5ac8894db4e3095