### PR TITLE
Fix PYQ quiz data and timer handling

### DIFF
--- a/app/src/main/assets/CDS_II_2024_English_SetA.json
+++ b/app/src/main/assets/CDS_II_2024_English_SetA.json
@@ -1291,12 +1291,12 @@
         "D": "No error"
       },
       "correct_answer": "C",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 72,
@@ -1308,12 +1308,12 @@
         "D": "No error"
       },
       "correct_answer": "C",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 73,
@@ -1325,12 +1325,12 @@
         "D": "No error"
       },
       "correct_answer": "B",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 74,
@@ -1342,12 +1342,12 @@
         "D": "No error"
       },
       "correct_answer": "D",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 75,
@@ -1359,12 +1359,12 @@
         "D": "No error"
       },
       "correct_answer": "B",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 76,
@@ -1376,12 +1376,12 @@
         "D": "No error"
       },
       "correct_answer": "A",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 77,
@@ -1393,12 +1393,12 @@
         "D": "No error"
       },
       "correct_answer": "C",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 78,
@@ -1410,12 +1410,12 @@
         "D": "No error"
       },
       "correct_answer": "B",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 79,
@@ -1427,12 +1427,12 @@
         "D": "No error"
       },
       "correct_answer": "B",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 80,
@@ -1444,12 +1444,12 @@
         "D": "No error"
       },
       "correct_answer": "C",
-      "topic": "",
-      "sub_topic": "",
+      "topic": "Grammar",
+      "sub_topic": "Error Spotting",
       "difficulty": "",
       "remarks": "",
       "passage_id": null,
-      "direction_id": null
+      "direction_id": "DIR_10"
     },
     {
       "question_number": 81,


### PR DESCRIPTION
## Summary
- tag missing PYQ questions with Grammar/Error Spotting and add directions
- size timer to question count for retakes and clear stale resume data

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f0b2ad548329b9b69509e835add5