### PR TITLE
feat: add onboarding and persistent quiz resume

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -21,8 +21,10 @@ It is intended to be updated whenever new features are added or existing functio
 
 #### Application & Navigation
 - `CdsApplication.kt` – Application class annotated with `@HiltAndroidApp` to bootstrap Hilt.
-- `MainActivity.kt` – Entry activity hosting the navigation scaffold and bottom bar.
+- `MainActivity.kt` – Entry activity hosting the navigation scaffold and bottom bar with first-run onboarding.
 - `core/navigation/NavGraph.kt` – Defines navigation routes for English dashboard, concepts, detail, and quiz screens.
+- `AppViewModel.kt` – Root view model exposing onboarding state.
+- `ui/onboarding/OnboardingScreen.kt` – Simple carousel shown on first launch.
 
 #### UI Screens
 - `ui/english/dashboard/EnglishDashboardScreen.kt` – Dashboard showing PYQ summary and navigation.
@@ -34,7 +36,7 @@ It is intended to be updated whenever new features are added or existing functio
 - `ui/english/pyqp/PyqpPaperListScreen.kt` – Lists available previous year papers.
 - `ui/english/pyqp/QuizScreen.kt` – Runs a quiz for a selected paper with a countdown timer (pause/resume on lifecycle events), question flagging and a palette for quick navigation, showing section intro pages and collapsible headers for passages or directions.
 - `ui/english/pyqp/PyqpListViewModel.kt`, `QuizViewModel.kt` – View models for paper list and quiz screens with paging and section intro logic.
-- `ui/english/quiz/QuizHubScreen.kt`, `QuizHubViewModel.kt` – Hub for starting or resuming previous year question practice and accessing analytics.
+- `ui/english/quiz/QuizHubScreen.kt`, `QuizHubViewModel.kt` – Hub for starting or resuming previous year question practice and accessing analytics with a snackbar to resume the last test.
 - `ui/english/quiz/QuizScreen.kt` – Placeholder quiz view for a topic.
 - `ui/english/analysis/AnalysisScreen.kt` – Placeholder analysis screen.
 
@@ -44,7 +46,7 @@ It is intended to be updated whenever new features are added or existing functio
 - `core/components/CdsCard.kt` – Convenience wrapper around Material `Card`.
 - `core/model/Subject.kt` – Enum describing supported subjects and associated icons.
 - `core/model/SubjectProgress.kt` – Model representing progress for a subject.
-- `core/theme/Color.kt`, `core/theme/Type.kt`, `core/theme/Theme.kt` – Material3 theme definitions and typography.
+- `core/theme/Color.kt`, `core/theme/Type.kt`, `core/theme/Theme.kt` – Material3 theme definitions and typography with custom light/dark color tokens.
 
 #### Domain & Data Layer
 - `domain/english/EnglishTopic.kt`, `EnglishQuestion.kt` – Domain models for topics and questions.
@@ -55,6 +57,8 @@ It is intended to be updated whenever new features are added or existing functio
 - `data/english/model/PyqpQuestionEntity.kt`, `PyqpProgress.kt` – Entities for previous year questions and progress.
 - `data/english/repo/EnglishRepository.kt` – Repository combining DAOs for higher-level operations.
 - `data/english/repo/PyqpRepository.kt` – Repository exposing PYQ papers and questions.
+- `data/quiz/QuizResumeStore.kt` – DataStore-backed persistence for resuming quizzes.
+- `data/settings/UserPreferences.kt` – Stores onboarding completion flag.
 
 #### Dependency Injection (`di/`)
 - `data/english/db/EnglishDatabaseModule.kt` – Provides the English Room database, DAOs, and repository.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.foundation)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(platform(libs.firebase.bom))   // <-- BOM now comes from catalog

--- a/app/src/main/java/com/concepts_and_quizzes/cds/AppViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/AppViewModel.kt
@@ -1,0 +1,24 @@
+package com.concepts_and_quizzes.cds
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import com.concepts_and_quizzes.cds.data.settings.UserPreferences
+
+@HiltViewModel
+class AppViewModel @Inject constructor(
+    private val prefs: UserPreferences
+) : ViewModel() {
+    val showOnboarding = prefs.onboardingDone
+        .map { !it }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
+    fun completeOnboarding() {
+        viewModelScope.launch { prefs.setOnboardingDone() }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
@@ -7,13 +7,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.concepts_and_quizzes.cds.core.components.CdsBottomNavBar
 import com.concepts_and_quizzes.cds.core.navigation.rootGraph
 import com.concepts_and_quizzes.cds.core.theme.CDSTheme
+import com.concepts_and_quizzes.cds.ui.onboarding.OnboardingScreen
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -29,25 +32,31 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun CDSApp() {
     CDSTheme {
-        val navController = rememberNavController()
-        val navBackStackEntry by navController.currentBackStackEntryAsState()
-        val currentRoute = navBackStackEntry?.destination?.route
-        val bottomBarRoutes = setOf(
-            "english/dashboard",
-            "english/concepts",
-            "quizHub",
-            "english/pyqp?mode={mode}&topic={topic}",
-            "analytics/pyq"
-        )
-        val showBottomBar = currentRoute in bottomBarRoutes
+        val appVm: AppViewModel = hiltViewModel()
+        val showOnboarding by appVm.showOnboarding.collectAsState()
+        if (showOnboarding) {
+            OnboardingScreen { appVm.completeOnboarding() }
+        } else {
+            val navController = rememberNavController()
+            val navBackStackEntry by navController.currentBackStackEntryAsState()
+            val currentRoute = navBackStackEntry?.destination?.route
+            val bottomBarRoutes = setOf(
+                "english/dashboard",
+                "english/concepts",
+                "quizHub",
+                "english/pyqp?mode={mode}&topic={topic}",
+                "analytics/pyq"
+            )
+            val showBottomBar = currentRoute in bottomBarRoutes
 
-        Scaffold(bottomBar = { if (showBottomBar) CdsBottomNavBar(navController) }) { padding ->
-            NavHost(
-                navController = navController,
-                startDestination = "english/dashboard",
-                modifier = Modifier.padding(padding)
-            ) {
-                rootGraph(navController)
+            Scaffold(bottomBar = { if (showBottomBar) CdsBottomNavBar(navController) }) { padding ->
+                NavHost(
+                    navController = navController,
+                    startDestination = "english/dashboard",
+                    modifier = Modifier.padding(padding)
+                ) {
+                    rootGraph(navController)
+                }
             }
         }
     }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/Color.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/Color.kt
@@ -2,10 +2,10 @@ package com.concepts_and_quizzes.cds.core.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+// Custom light theme colors
+val LightPrimary = Color(0xFF0061A5)
+val LightSecondary = Color(0xFF006874)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+// Custom dark theme colors
+val DarkPrimary = Color(0xFF9CCAFF)
+val DarkSecondary = Color(0xFF4FD8EB)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/Theme.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.concepts_and_quizzes.cds.core.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -12,25 +11,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    primary = DarkPrimary,
+    secondary = DarkSecondary
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = LightPrimary,
+    secondary = LightSecondary
 )
 
 @Composable

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/quiz/QuizResumeStore.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/quiz/QuizResumeStore.kt
@@ -1,18 +1,45 @@
 package com.concepts_and_quizzes.cds.data.quiz
 
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+private val Context.quizDataStore by preferencesDataStore(name = "quiz_resume")
 
 @Singleton
-class QuizResumeStore @Inject constructor() {
+class QuizResumeStore @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
     data class Store(val paperId: String, val snapshot: String)
 
+    private val PAPER_ID = stringPreferencesKey("paper_id")
+    private val SNAPSHOT = stringPreferencesKey("snapshot")
+
+    private val scope = CoroutineScope(Dispatchers.IO)
     private val _store = MutableStateFlow<Store?>(null)
     val store: StateFlow<Store?> = _store
 
-    fun save(
+    init {
+        scope.launch {
+            context.quizDataStore.data.map { prefs ->
+                val id = prefs[PAPER_ID]
+                val snap = prefs[SNAPSHOT]
+                if (id != null && snap != null) Store(id, snap) else null
+            }.collect { _store.value = it }
+        }
+    }
+
+    suspend fun save(
         paperId: String,
         answers: Map<Int, Int>,
         flags: Set<Int>,
@@ -24,14 +51,17 @@ class QuizResumeStore @Inject constructor() {
         val flg = flags.joinToString(",")
         val dur = durations.entries.joinToString(";") { "${it.key}:${it.value}" }
         val snapshot = listOf(pageIndex, ans, flg, remaining, dur).joinToString("|")
-        _store.value = Store(paperId, snapshot)
+        context.quizDataStore.edit { prefs ->
+            prefs[PAPER_ID] = paperId
+            prefs[SNAPSHOT] = snapshot
+        }
     }
 
-    fun restore(snapshot: String) {
-        _store.value = _store.value?.copy(snapshot = snapshot)
+    suspend fun restore(snapshot: String) {
+        context.quizDataStore.edit { it[SNAPSHOT] = snapshot }
     }
 
-    fun clear() {
-        _store.value = null
+    suspend fun clear() {
+        context.quizDataStore.edit { it.clear() }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/settings/UserPreferences.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/settings/UserPreferences.kt
@@ -1,0 +1,27 @@
+package com.concepts_and_quizzes.cds.data.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.userPrefsDataStore by preferencesDataStore(name = "user_prefs")
+
+@Singleton
+class UserPreferences @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val ONBOARDING_DONE = booleanPreferencesKey("onboarding_done")
+
+    val onboardingDone: Flow<Boolean> =
+        context.userPrefsDataStore.data.map { it[ONBOARDING_DONE] ?: false }
+
+    suspend fun setOnboardingDone() {
+        context.userPrefsDataStore.edit { it[ONBOARDING_DONE] = true }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -100,7 +100,7 @@ class QuizViewModel @Inject constructor(
         if (s != null && s.paperId == quizId) {
             restore(s.snapshot)
         } else {
-            resumeStore.clear()
+            viewModelScope.launch { resumeStore.clear() }
             pageIndex = 0
             _timer.value = state["timerSec"] ?: defaultTime()
             state["timerSec"] = _timer.value
@@ -190,7 +190,7 @@ class QuizViewModel @Inject constructor(
         timerJob?.cancel()
         timerJob = null
         state["timerSec"] = _timer.value
-        resumeStore.save(quizId, answers, flags, pageIndex, _timer.value, durations)
+        viewModelScope.launch { resumeStore.save(quizId, answers, flags, pageIndex, _timer.value, durations) }
     }
 
     fun resume() {
@@ -331,7 +331,7 @@ class QuizViewModel @Inject constructor(
         _result.value = QuizResult(attempts.count { it.correct }, questions.size)
         _showResult.value = true
         state["showResult"] = true
-        resumeStore.clear()
+        viewModelScope.launch { resumeStore.clear() }
         state.remove<Int>("timerSec")
     }
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
@@ -5,10 +5,16 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -18,46 +24,52 @@ import com.concepts_and_quizzes.cds.core.components.CdsCard
 @Composable
 fun QuizHubScreen(nav: NavHostController, vm: QuizHubViewModel = hiltViewModel()) {
     val store by vm.store.collectAsState()
-    Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        Text("Quiz Hub")
-        CdsCard {
-            Column(
-                Modifier
-                    .clickable { nav.navigate("english/pyqp") }
-                    .padding(16.dp)
-            ) {
-                Text("Start PYQ")
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(store) {
+        store?.let { s ->
+            val result = snackbarHostState.showSnackbar(
+                message = "Resume last test?",
+                actionLabel = "Resume"
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                val dest = if (s.paperId.startsWith("WRONGS:")) {
+                    val topic = Uri.encode(s.paperId.removePrefix("WRONGS:"))
+                    "english/pyqp?mode=WRONGS&topic=$topic"
+                } else {
+                    "english/pyqp/${s.paperId}"
+                }
+                nav.navigate(dest) {
+                    popUpTo("quizHub")
+                }
+                vm.restore(s.snapshot)
             }
         }
-        store?.let { s ->
+    }
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+        Column(
+            Modifier
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text("Quiz Hub")
             CdsCard {
                 Column(
                     Modifier
-                        .clickable {
-                            val dest = if (s.paperId.startsWith("WRONGS:")) {
-                                val topic = Uri.encode(s.paperId.removePrefix("WRONGS:"))
-                                "english/pyqp?mode=WRONGS&topic=$topic"
-                            } else {
-                                "english/pyqp/${s.paperId}"
-                            }
-                            nav.navigate(dest) {
-                                popUpTo("quizHub")
-                            }
-                            vm.restore(s.snapshot)
-                        }
+                        .clickable { nav.navigate("english/pyqp") }
                         .padding(16.dp)
                 ) {
-                    Text("Resume PYQ")
+                    Text("Start PYQ")
                 }
             }
-        }
-        CdsCard {
-            Column(
-                Modifier
-                    .clickable { nav.navigate("analytics/pyq") }
-                    .padding(16.dp)
-            ) {
-                Text("Analytics")
+            CdsCard {
+                Column(
+                    Modifier
+                        .clickable { nav.navigate("analytics/pyq") }
+                        .padding(16.dp)
+                ) {
+                    Text("Analytics")
+                }
             }
         }
     }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubViewModel.kt
@@ -1,9 +1,11 @@
 package com.concepts_and_quizzes.cds.ui.english.quiz
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import com.concepts_and_quizzes.cds.data.quiz.QuizResumeStore
 
 @HiltViewModel
@@ -13,6 +15,6 @@ class QuizHubViewModel @Inject constructor(
     val store: StateFlow<QuizResumeStore.Store?> = resumeStore.store
 
     fun restore(snapshot: String) {
-        resumeStore.restore(snapshot)
+        viewModelScope.launch { resumeStore.restore(snapshot) }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/onboarding/OnboardingScreen.kt
@@ -1,0 +1,51 @@
+package com.concepts_and_quizzes.cds.ui.onboarding
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun OnboardingScreen(onFinish: () -> Unit) {
+    val pages = listOf(
+        "Dashboard helps track progress",
+        "Concepts contain study material",
+        "PYQP lets you practice exams"
+    )
+    val pagerState = rememberPagerState(initialPage = 0, pageCount = { pages.size })
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(pages[page])
+            }
+        }
+        Button(
+            onClick = {
+                if (pagerState.currentPage < pages.lastIndex) {
+                    scope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
+                } else {
+                    onFinish()
+                }
+            },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        ) {
+            Text(if (pagerState.currentPage == pages.lastIndex) "Start" else "Next")
+        }
+    }
+}

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
@@ -12,6 +12,8 @@ import com.concepts_and_quizzes.cds.data.english.db.PyqpProgressDao
 import com.concepts_and_quizzes.cds.data.english.model.PyqpProgress
 import com.concepts_and_quizzes.cds.data.english.model.PyqpQuestionEntity
 import com.concepts_and_quizzes.cds.data.english.repo.PyqpRepository
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import com.concepts_and_quizzes.cds.data.quiz.QuizResumeStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -75,7 +77,8 @@ class QuizViewModelTest {
         }
         val analytics = AnalyticsRepository(attemptDao, topicStatDao)
         val repo = PyqpRepository(dao, attemptDao)
-        val vm = QuizViewModel(repo, progressDao, analytics, QuizResumeStore(), SavedStateHandle(mapOf("paperId" to "paper")))
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val vm = QuizViewModel(repo, progressDao, analytics, QuizResumeStore(context), SavedStateHandle(mapOf("paperId" to "paper")))
         advanceUntilIdle()
 
         val q1 = vm.pageContent(0) as QuizViewModel.QuizPage.Question
@@ -128,11 +131,12 @@ class QuizViewModelTest {
         }
         val analytics = AnalyticsRepository(attemptDao, topicStatDao)
         val repo = PyqpRepository(dao, attemptDao)
+        val context = ApplicationProvider.getApplicationContext<Context>()
         val vm = QuizViewModel(
             repo,
             progressDao,
             analytics,
-            QuizResumeStore(),
+            QuizResumeStore(context),
             SavedStateHandle(mapOf("mode" to "WRONGS", "topic" to "grammar"))
         )
         advanceUntilIdle()
@@ -165,7 +169,8 @@ class QuizViewModelTest {
         }
         val analytics = AnalyticsRepository(attemptDao, topicStatDao)
         val repo = PyqpRepository(dao, attemptDao)
-        val resumeStore = QuizResumeStore()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val resumeStore = QuizResumeStore(context)
         resumeStore.save("paper", mapOf(1 to 2), setOf(1), 1, 0, mapOf(1 to 500))
         val vm = QuizViewModel(repo, progressDao, analytics, resumeStore, SavedStateHandle(mapOf("paperId" to "paper")))
         advanceUntilIdle()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 credentials              = { module = "androidx.credentials:credentials",                     version.ref = "credentials" }
 credentials-playservices = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }


### PR DESCRIPTION
## Summary
- add first-run onboarding carousel and view model
- persist quiz state via DataStore and surface resume snackbar
- define light/dark color tokens for Material theme

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936615b05c8329b9763e25b763a0f1