### PR TITLE
Revamp dashboard into hero landing with discover carousel

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -27,8 +27,8 @@ It is intended to be updated whenever new features are added or existing functio
 - `ui/onboarding/OnboardingScreen.kt` – Simple carousel shown on first launch.
 
 #### UI Screens
-- `ui/english/dashboard/EnglishDashboardScreen.kt` – Dashboard showing PYQ summary and navigation.
-- `ui/english/dashboard/EnglishDashboardViewModel.kt` – Supplies dashboard data.
+- `ui/english/dashboard/EnglishDashboardScreen.kt` – Hero landing with greeting, progress ring, action chips, live stats and a discover carousel.
+- `ui/english/dashboard/EnglishDashboardViewModel.kt` – Supplies dashboard data including questions practised and concept-of-the-day cards.
 - `ui/english/concepts/ConceptsHomeViewModel.kt` – Exposes English topics from the repository.
 - `ui/english/concepts/ConceptsHomeScreen.kt` – Lists topics and navigates to their details.
 - `ui/english/concepts/ConceptDetailViewModel.kt` – Loads a single topic based on navigation arguments.
@@ -70,6 +70,7 @@ It is intended to be updated whenever new features are added or existing functio
 - `src/main/res/xml/` – Backup and data extraction configuration.
 - `src/main/assets/english_seed.json` – Seed data for populating the English database.
 - `src/main/assets/CDS_II_2024_English_SetA.json` – PYQ sample exam data used by the quiz screen.
+- `src/main/assets/concept_of_the_day.json` – Concepts for the dashboard discover carousel.
 
 ### Tests
 - `src/test/java/.../ExampleUnitTest.kt` – Sample unit test.

--- a/app/src/main/assets/concept_of_the_day.json
+++ b/app/src/main/assets/concept_of_the_day.json
@@ -1,0 +1,7 @@
+{
+  "concepts": [
+    { "id": "c1", "title": "Active Voice", "overview": "Subject performs the action denoted by the verb." },
+    { "id": "c2", "title": "Passive Voice", "overview": "Subject receives the action expressed by the verb." },
+    { "id": "c3", "title": "Direct Speech", "overview": "Reporting the exact words spoken by someone." }
+  ]
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -1,35 +1,208 @@
 package com.concepts_and_quizzes.cds.ui.english.dashboard
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoStories
+import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.filled.QuestionAnswer
+import androidx.compose.material.icons.filled.School
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.concepts_and_quizzes.cds.core.components.CdsCard
+import java.time.LocalTime
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 
+@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
 @Composable
 fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel = hiltViewModel()) {
     val summary by vm.summary.collectAsState()
-    Column(modifier = Modifier.padding(16.dp)) {
-        Text("English Dashboard")
-        CdsCard {
-            Column(
+    val questionsToday by vm.questionsToday.collectAsState()
+    val concepts by vm.concepts.collectAsState()
+    val count by animateIntAsState(targetValue = questionsToday, label = "count")
+
+    val greeting = remember {
+        val hour = LocalTime.now().hour
+        val part = when (hour) {
+            in 5..11 -> "Morning"
+            in 12..17 -> "Afternoon"
+            else -> "Evening"
+        }
+        "$part revision, Magnus!"
+    }
+
+    Column {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .height(90.dp)
+                .graphicsLayer {
+                    clip = true
+                    shape = RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp)
+                    shadowElevation = 8f
+                }
+                .background(
+                    Brush.radialGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.primary,
+                            MaterialTheme.colorScheme.primaryContainer
+                        )
+                    )
+                )
+        ) {
+            Row(
                 Modifier
-                    .clickable { nav.navigate("analytics/pyq") }
-                    .padding(16.dp)
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text("PYQ Summary")
-                Text("• Papers: ${summary.papers}")
-                Text("• Best: ${summary.best}%")
-                Text("• Last: ${summary.last}%")
-                Text("View All")
+                Text(
+                    greeting,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+                CircularProgressIndicator(
+                    progress = summary.best / 100f,
+                    modifier = Modifier.size(48.dp)
+                )
+            }
+        }
+
+        FlowRow(
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 24.dp),
+            mainAxisSpacing = 8.dp,
+            crossAxisSpacing = 8.dp
+        ) {
+            ActionChip(Icons.Filled.AutoStories, "Concepts") { nav.navigate("english/concepts") }
+            ActionChip(Icons.Filled.School, "Mock Tests") { nav.navigate("quizHub") }
+            ActionChip(Icons.Filled.MenuBook, "Past Papers") { nav.navigate("english/pyqp") }
+        }
+
+        Row(
+            Modifier.padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(Icons.Filled.QuestionAnswer, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text("$count Questions practised today")
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            "Discover",
+            modifier = Modifier.padding(start = 16.dp, bottom = 8.dp),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        val listState = rememberLazyListState()
+        val fling = rememberSnapFlingBehavior(listState)
+        LazyRow(
+            state = listState,
+            flingBehavior = fling,
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(concepts) { concept ->
+                Box(
+                    Modifier
+                        .width(200.dp)
+                        .height(120.dp)
+                ) {
+                    CdsCard(Modifier.matchParentSize()) {
+                        Column(Modifier.padding(16.dp)) {
+                            Text(
+                                concept.title,
+                                style = MaterialTheme.typography.titleMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                concept.overview,
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                    Box(
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .offset(x = 12.dp, y = (-12).dp)
+                            .size(24.dp)
+                            .graphicsLayer { rotationZ = 45f }
+                            .background(MaterialTheme.colorScheme.secondaryContainer)
+                    )
+                }
             }
         }
     }
 }
+
+@Composable
+private fun ActionChip(icon: ImageVector, label: String, onClick: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+    val scale by animateFloatAsState(targetValue = if (pressed) 0.95f else 1f, label = "scale")
+
+    Surface(
+        modifier = Modifier
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .clickable(interactionSource = interaction, indication = null, onClick = onClick),
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.secondaryContainer
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(icon, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(label)
+        }
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardViewModel.kt
@@ -1,21 +1,29 @@
 package com.concepts_and_quizzes.cds.ui.english.dashboard
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.concepts_and_quizzes.cds.data.english.db.PyqpProgressDao
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.json.JSONObject
 
 @HiltViewModel
 class EnglishDashboardViewModel @Inject constructor(
-    progressDao: PyqpProgressDao
+    progressDao: PyqpProgressDao,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
     data class PyqSummary(val papers: Int, val best: Int, val last: Int)
+
+    data class Concept(val id: String, val title: String, val overview: String)
 
     val summary: StateFlow<PyqSummary> = progressDao.getAll()
         .map { list ->
@@ -24,4 +32,30 @@ class EnglishDashboardViewModel @Inject constructor(
             PyqSummary(list.size, best, last)
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), PyqSummary(0,0,0))
+
+    val questionsToday: StateFlow<Int> = progressDao.getAll()
+        .map { list -> list.sumOf { it.attempted } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
+
+    private val _concepts = MutableStateFlow<List<Concept>>(emptyList())
+    val concepts: StateFlow<List<Concept>> = _concepts
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            _concepts.value = loadConcepts()
+        }
+    }
+
+    private fun loadConcepts(): List<Concept> = runCatching {
+        val json = context.assets.open("concept_of_the_day.json").bufferedReader().use { it.readText() }
+        val array = JSONObject(json).getJSONArray("concepts")
+        List(array.length()) { idx ->
+            val obj = array.getJSONObject(idx)
+            Concept(
+                id = obj.optString("id"),
+                title = obj.optString("title"),
+                overview = obj.optString("overview")
+            )
+        }
+    }.getOrDefault(emptyList())
 }


### PR DESCRIPTION
## Summary
- Recompose English dashboard with hero header, action chips, live stats, and concept carousel
- Load concept-of-the-day data from assets for discover section
- Document new dashboard components and asset

## Testing
- `./gradlew test` *(fails: Could not determine dependencies; SDK packages not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68942eb2d11c8329b6b7fda8a31ccffa