### PR TITLE
Use application instance to load dashboard assets

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/CdsApplication.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/CdsApplication.kt
@@ -15,8 +15,14 @@ class CdsApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        instance = this
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
             seedUtil.seedIfEmpty()
         }
+    }
+
+    companion object {
+        lateinit var instance: CdsApplication
+            private set
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardViewModel.kt
@@ -1,11 +1,10 @@
 package com.concepts_and_quizzes.cds.ui.english.dashboard
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.concepts_and_quizzes.cds.CdsApplication
 import com.concepts_and_quizzes.cds.data.english.db.PyqpProgressDao
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,8 +17,7 @@ import org.json.JSONObject
 
 @HiltViewModel
 class EnglishDashboardViewModel @Inject constructor(
-    progressDao: PyqpProgressDao,
-    @ApplicationContext private val context: Context
+    private val progressDao: PyqpProgressDao
 ) : ViewModel() {
     data class PyqSummary(val papers: Int, val best: Int, val last: Int)
 
@@ -47,7 +45,10 @@ class EnglishDashboardViewModel @Inject constructor(
     }
 
     private fun loadConcepts(): List<Concept> = runCatching {
-        val json = context.assets.open("concept_of_the_day.json").bufferedReader().use { it.readText() }
+        val json = CdsApplication.instance.assets
+            .open("concept_of_the_day.json")
+            .bufferedReader()
+            .use { it.readText() }
         val array = JSONObject(json).getJSONArray("concepts")
         List(array.length()) { idx ->
             val obj = array.getJSONObject(idx)


### PR DESCRIPTION
## Summary
- expose `CdsApplication` instance for global access
- refactor `EnglishDashboardViewModel` to use `CdsApplication` instead of injecting `Context`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68943503cbc88329ae0a4a39e51030ec