### PR TITLE
Inject DiscoverRepository via constructor

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/discover/DiscoverRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/discover/DiscoverRepository.kt
@@ -5,13 +5,15 @@ import com.concepts_and_quizzes.cds.data.discover.model.BookmarkEntity
 import com.concepts_and_quizzes.cds.data.discover.model.ConceptEntity
 import com.concepts_and_quizzes.cds.data.discover.model.DailyTipEntity
 import java.time.LocalDate
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.first
 
-class DiscoverRepository(
+@Singleton
+class DiscoverRepository @Inject constructor(
     private val dao: ConceptDao
 ) {
     private val tipsPerDay = 3

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabaseModule.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabaseModule.kt
@@ -8,7 +8,6 @@ import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao
 import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
 import com.concepts_and_quizzes.cds.data.discover.db.ConceptDao
-import com.concepts_and_quizzes.cds.data.discover.DiscoverRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -69,9 +68,4 @@ object EnglishDatabaseModule {
     ): AnalyticsRepository =
         AnalyticsRepository(attemptDao, topicStatDao)
 
-    @Provides
-    @Singleton
-    fun provideDiscoverRepository(
-        conceptDao: ConceptDao
-    ): DiscoverRepository = DiscoverRepository(conceptDao)
 }


### PR DESCRIPTION
## Summary
- Convert `DiscoverRepository` to use constructor injection with `@Singleton` and `@Inject`.
- Remove redundant Hilt provider for `DiscoverRepository` from `EnglishDatabaseModule`.

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894426326948329b3bf8e414ca56cc6