### PR TITLE
Handle tip rotation edge cases and improve accessibility

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/discover/DiscoverRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/discover/DiscoverRepository.kt
@@ -28,10 +28,17 @@ class DiscoverRepository @Inject constructor(
         if (existing.size == tipsPerDay) return existing
 
         var pool = dao.unservedConceptIds()
-        if (pool.size < tipsPerDay) {
+
+        if (existing.isEmpty() && pool.isEmpty()) {
             dao.clearDailyTipHistory()
             pool = dao.unservedConceptIds()
         }
+
+        if (pool.size < tipsPerDay) {
+            dao.clearDailyTipHistory()
+            pool = dao.unservedConceptIds().ifEmpty { dao.allConceptIds() }
+        }
+
         val draw = pool.shuffled().take(tipsPerDay).map { DailyTipEntity(today, it) }
         dao.insertDailyTips(draw)
         return draw

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/discover/db/ConceptDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/discover/db/ConceptDao.kt
@@ -34,6 +34,9 @@ interface ConceptDao {
     @Query("SELECT id FROM concept WHERE id NOT IN (SELECT conceptId FROM daily_tip)")
     suspend fun unservedConceptIds(): List<Int>
 
+    @Query("SELECT id FROM concept")
+    suspend fun allConceptIds(): List<Int>
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun addBookmark(bookmark: BookmarkEntity)
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/DiscoverComponents.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/DiscoverComponents.kt
@@ -2,6 +2,7 @@ package com.concepts_and_quizzes.cds.ui.english.dashboard
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -24,6 +25,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.concepts_and_quizzes.cds.data.discover.model.ConceptEntity
@@ -45,7 +48,17 @@ fun DiscoverCard(
         Column(Modifier.padding(20.dp)) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                 Text(concept.title, style = MaterialTheme.typography.titleMedium)
-                IconToggleButton(checked = bookmarked, onCheckedChange = { onBookmark() }) {
+                IconToggleButton(
+                    checked = bookmarked,
+                    onCheckedChange = { onBookmark() },
+                    modifier = Modifier.semantics {
+                        contentDescription = if (bookmarked) {
+                            "Remove bookmark"
+                        } else {
+                            "Add bookmark"
+                        }
+                    }
+                ) {
                     Icon(
                         imageVector = if (bookmarked) Icons.Filled.Star else Icons.Outlined.StarBorder,
                         contentDescription = null
@@ -65,6 +78,8 @@ fun DiscoverCarousel(
     nav: NavController
 ) {
     LazyRow(
+        modifier = Modifier.focusable(),
+        reverseLayout = false,
         contentPadding = PaddingValues(horizontal = 24.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {


### PR DESCRIPTION
## Summary
- prevent premature tip repeats and regenerate when date skips ahead
- expose full concept ID set via DAO
- add TalkBack label for bookmark toggle and make carousel D-pad focusable

## Testing
- `./gradlew detekt ktlintCheck lintDebug test` *(fails: Task 'detekt' not found)*
- `./gradlew ktlintCheck lintDebug test` *(fails: Task 'ktlintCheck' not found)*
- `./gradlew lintDebug test` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944b19ea7c8329a1ff50155654e034