### PR TITLE
Fix splash screen branding attribute namespace

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,7 +4,7 @@
     <style name="Theme.CDS" parent="android:Theme.Material.Light.NoActionBar" />
 
     <style name="Theme.CDS.Launch" parent="@style/Theme.SplashScreen">
-        <item name="windowSplashScreenBrandingImage">@drawable/logo</item>
+        <item name="android:windowSplashScreenBrandingImage">@drawable/logo</item>
         <item name="windowSplashScreenBackground">@color/primaryContainer</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- prefix splash screen branding attribute with the android namespace to avoid missing resource linking errors

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689469abab5483298cfe3f3954c1c97a