### PR TITLE
Use PNG logo and add splash screen

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/components/AppBar.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/components/AppBar.kt
@@ -2,12 +2,13 @@ package com.concepts_and_quizzes.cds.core.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.concepts_and_quizzes.cds.R
@@ -19,10 +20,11 @@ fun CdsAppBar(title: String) {
         title = { Text(text = title) },
         navigationIcon = {
             Image(
-                painter = painterResource(R.drawable.logo2),
+                painter = painterResource(R.drawable.logo),
                 contentDescription = null,
+                contentScale = ContentScale.Fit,
                 modifier = Modifier
-                    .size(32.dp)
+                    .width(32.dp)
                     .padding(start = 8.dp)
             )
         }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.filled.AutoStories
 import androidx.compose.material.icons.filled.QuestionAnswer
 import androidx.compose.material.icons.filled.School
@@ -33,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -72,10 +74,11 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
 
     Column {
         Image(
-            painter = painterResource(R.drawable.logo2),
+            painter = painterResource(R.drawable.logo),
             contentDescription = "CDS logo",
+            contentScale = ContentScale.Fit,
             modifier = Modifier
-                .size(96.dp)
+                .width(96.dp)
                 .align(Alignment.CenterHorizontally)
         )
         Spacer(Modifier.height(16.dp))

--- a/app/src/main/res/drawable-night/logo2.xml
+++ b/app/src/main/res/drawable-night/logo2.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="96dp"
-    android:height="96dp"
-    android:viewportWidth="96"
-    android:viewportHeight="96">
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M48,8a40,40 0 1,0 0,80a40,40 0 1,0 0,-80z" />
-</vector>

--- a/app/src/main/res/drawable/logo2.xml
+++ b/app/src/main/res/drawable/logo2.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="96dp"
-    android:height="96dp"
-    android:viewportWidth="96"
-    android:viewportHeight="96">
-    <path
-        android:fillColor="#000000"
-        android:pathData="M48,8a40,40 0 1,0 0,80a40,40 0 1,0 0,-80z" />
-</vector>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,7 +4,7 @@
     <style name="Theme.CDS" parent="android:Theme.Material.Light.NoActionBar" />
 
     <style name="Theme.CDS.Launch" parent="@style/Theme.SplashScreen">
-        <item name="android:windowSplashScreenBrandingImage">@drawable/logo</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/logo</item>
         <item name="windowSplashScreenBackground">@color/primaryContainer</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- Use PNG logo exclusively and update app bar/dashboard icon usage
- Configure splash screen to show PNG logo
- Remove unused vector logo assets

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68946d1c6c60832982158c4684a64415