### PR TITLE
Remove default top app bar

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DiscoverConceptDetailScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DiscoverConceptDetailScreen.kt
@@ -2,13 +2,6 @@ package com.concepts_and_quizzes.cds.ui.english.discover
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.outlined.StarBorder
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -20,32 +13,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DiscoverConceptDetailScreen(nav: NavHostController, vm: DiscoverConceptViewModel = hiltViewModel()) {
     val concept by vm.concept.collectAsState()
-    val bookmarked by vm.bookmarked.collectAsState()
 
-    Scaffold(
-        topBar = {
-            androidx.compose.material3.TopAppBar(
-                title = { Text(concept?.title ?: "") },
-                navigationIcon = {
-                    IconButton(onClick = { nav.popBackStack() }) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                actions = {
-                    IconButton(onClick = { vm.toggleBookmark() }) {
-                        Icon(
-                            imageVector = if (bookmarked) Icons.Filled.Star else Icons.Outlined.StarBorder,
-                            contentDescription = null
-                        )
-                    }
-                }
-            )
-        }
-    ) { padding ->
+    Scaffold { padding ->
         concept?.let { c ->
             Column(Modifier.padding(padding).padding(16.dp)) {
                 Text(c.detail, style = MaterialTheme.typography.bodyLarge)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqAnalyticsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -18,7 +17,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -50,7 +48,7 @@ fun PyqAnalyticsScreen(
     val tab by vm.tab.collectAsState()
     var highContrast by remember { mutableStateOf(false) }
 
-    Scaffold(topBar = { TopAppBar(title = { Text("PYQ Analytics") }) }) { pad ->
+    Scaffold { pad ->
         Column(Modifier.padding(pad).padding(16.dp)) {
             FilterChipRow(vm)
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpPaperListScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpPaperListScreen.kt
@@ -16,13 +16,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
-import com.concepts_and_quizzes.cds.core.components.CdsAppBar
 import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
 fun PyqpPaperListScreen(nav: NavController, vm: PyqpListViewModel = hiltViewModel()) {
     val papers by vm.papers.collectAsState()
-    Scaffold(topBar = { CdsAppBar(title = "PYQ Papers") }) { padd ->
+    Scaffold { padd ->
         LazyColumn(contentPadding = padd) {
             items(papers) { paper ->
                 ListItem(

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.CDS" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.CDS" parent="Theme.Material3.DayNight.NoActionBar" />
 
     <style name="Theme.CDS.Launch" parent="@style/Theme.SplashScreen">
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/logo</item>
         <item name="windowSplashScreenBackground">@color/primaryContainer</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- Drop top bars from concept detail, PYQ analytics, and PYQ paper list screens
- Switch to a Material3 NoActionBar theme and disable the action bar in the splash theme

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947673734483299e3efc825ff77524