### PR TITLE
Remove unsupported beyondBoundsItemCount from LazyRow

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/DiscoverComponents.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/DiscoverComponents.kt
@@ -93,8 +93,7 @@ fun DiscoverCarousel(
         modifier = Modifier.focusable(),
         reverseLayout = false,
         contentPadding = PaddingValues(horizontal = 24.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-        beyondBoundsItemCount = 1
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         items(tips, key = { it.id }) { concept ->
             val bookmarked by vm.isBookmarked(concept.id).collectAsState(initial = false)


### PR DESCRIPTION
## Summary
- remove `beyondBoundsItemCount` parameter from `DiscoverCarousel` `LazyRow`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689482eaf7c88329ad6d5ad6fbc8c0df