### PR TITLE
Refine Discover sheet typography and spacing

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/Dimens.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/Dimens.kt
@@ -1,0 +1,11 @@
+package com.concepts_and_quizzes.cds.core.theme
+
+import androidx.compose.ui.unit.dp
+
+object Dimens {
+    val SheetPaddingX = 24.dp
+    val SheetPaddingTop = 28.dp
+    val ParagraphSpacing = 16.dp
+    val BulletIndent = 12.dp
+    val ChipSpacingX = 8.dp
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/Type.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/Type.kt
@@ -8,27 +8,37 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import com.concepts_and_quizzes.cds.R
 
-private val PlusJakartaSans = FontFamily(Font(R.font.plus_jakarta_sans))
+private val plusJakarta = FontFamily(Font(R.font.plus_jakarta_sans))
 
-// Set of Material typography styles to start with
 val Typography = Typography(
-    displayLarge = TextStyle(
-        fontFamily = PlusJakartaSans,
-        fontWeight = FontWeight.Bold
-    ),
     headlineSmall = TextStyle(
-        fontFamily = PlusJakartaSans,
-        fontWeight = FontWeight.Medium
+        fontFamily = plusJakarta,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 24.sp,
+        lineHeight = 32.sp
     ),
-    labelMedium = TextStyle(
-        fontFamily = PlusJakartaSans,
-        fontWeight = FontWeight.Medium
+    titleMedium = TextStyle(
+        fontFamily = plusJakarta,
+        fontWeight = FontWeight.Medium,
+        fontSize = 18.sp,
+        lineHeight = 28.sp
     ),
-    bodyLarge = TextStyle(
-        fontFamily = PlusJakartaSans,
+    bodyMedium = TextStyle(
+        fontFamily = plusJakarta,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
+        lineHeight = 24.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = plusJakarta,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = plusJakarta,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp
     )
 )

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material3.ProgressIndicatorDefaults
 import com.concepts_and_quizzes.cds.R
+import com.concepts_and_quizzes.cds.core.theme.Dimens
 
 @RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
@@ -112,8 +113,8 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
         FlowRow(
             modifier = Modifier
                 .padding(horizontal = 16.dp, vertical = 24.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(Dimens.ChipSpacingX),
+            verticalArrangement = Arrangement.spacedBy(Dimens.ChipSpacingX)
         ) {
             ActionChip(Icons.Filled.AutoStories, "Concepts") { nav.navigate("english/concepts") }
             ActionChip(Icons.Filled.School, "Mock Tests") { nav.navigate("quizHub") }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DetailSheetComponents.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DetailSheetComponents.kt
@@ -1,0 +1,40 @@
+package com.concepts_and_quizzes.cds.ui.english.discover
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.weight
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.concepts_and_quizzes.cds.core.theme.Dimens
+
+@Composable
+fun StyledParagraph(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.fillMaxWidth(),
+        textAlign = TextAlign.Start
+    )
+    Spacer(Modifier.height(Dimens.ParagraphSpacing))
+}
+
+@Composable
+fun Bullet(text: String) = Row(
+    modifier = Modifier.padding(start = Dimens.BulletIndent)
+) {
+    Text("•", style = MaterialTheme.typography.labelLarge)
+    Spacer(Modifier.width(8.dp))
+    Text(
+        text,
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.weight(1f)
+    )
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DiscoverConceptDetailScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DiscoverConceptDetailScreen.kt
@@ -1,26 +1,81 @@
 package com.concepts_and_quizzes.cds.ui.english.discover
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.verticalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import com.concepts_and_quizzes.cds.core.theme.Dimens
 
 @Composable
 fun DiscoverConceptDetailScreen(nav: NavHostController, vm: DiscoverConceptViewModel = hiltViewModel()) {
     val concept by vm.concept.collectAsState()
+    val bookmarked by vm.bookmarked.collectAsState()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    Scaffold { padding ->
-        concept?.let { c ->
-            Column(Modifier.padding(padding).padding(16.dp)) {
-                Text(c.detail, style = MaterialTheme.typography.bodyLarge)
+    concept?.let { c ->
+        ModalBottomSheet(
+            onDismissRequest = { nav.navigateUp() },
+            sheetState = sheetState,
+            containerColor = MaterialTheme.colorScheme.background,
+            tonalElevation = 3.dp,
+            shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = Dimens.SheetPaddingX, vertical = Dimens.SheetPaddingTop)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(Dimens.ParagraphSpacing)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(c.title, style = MaterialTheme.typography.headlineSmall)
+                    IconToggleButton(
+                        checked = bookmarked,
+                        onCheckedChange = { vm.toggleBookmark() }
+                    ) {
+                        Icon(
+                            imageVector = if (bookmarked) Icons.Filled.Star else Icons.Outlined.StarBorder,
+                            contentDescription = null,
+                            tint = if (bookmarked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+                val paragraphs = c.detail.split("\n\n")
+                paragraphs.forEach { StyledParagraph(it) }
+                val bullets = emptyList<String>()
+                bullets.forEach { Bullet(it) }
+                Spacer(Modifier.height(32.dp))
+                Button(
+                    onClick = { nav.navigate("concept/${c.id}") },
+                    modifier = Modifier.fillMaxWidth()
+                ) { Text("Full Lesson") }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Define Plus Jakarta typography tokens for headline, title, body, and labels with explicit line-heights.
- Introduce dimensional tokens for sheet padding, paragraphs, bullets, and chip spacing.
- Build styled paragraph and bullet composables and switch Discover detail screen to a ModalBottomSheet using new tokens.
- Use shared chip spacing token on dashboard.

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68948a4f3ef88329a15fea9b6d5da471