### PR TITLE
feat: replace tip bottom sheet with screen

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -30,7 +30,7 @@ It is intended to be updated whenever new features are added or existing functio
 - `ui/english/dashboard/EnglishDashboardScreen.kt` – Hero landing with greeting, progress ring, action chips, live stats and a discover carousel.
 - `ui/english/dashboard/EnglishDashboardViewModel.kt` – Supplies dashboard data including questions practised and daily tips with bookmarking.
 - `ui/english/dashboard/DiscoverComponents.kt` – Card and carousel composables for daily tips with pre-cached items to reduce jank.
-- `ui/english/discover/DiscoverConceptDetailScreen.kt` – Detail view for a tip with bookmarking.
+- `ui/english/discover/DiscoverConceptDetailScreen.kt` – Full-screen detail view for a tip with bookmarking and a tip icon.
 - `ui/english/discover/DiscoverConceptViewModel.kt` – Loads a single tip and exposes bookmark state.
 - `ui/english/concepts/ConceptsHomeViewModel.kt` – Exposes English topics and bookmarked tips.
 - `ui/english/concepts/ConceptsHomeScreen.kt` – Lists topics with a Bookmarks tab for saved tips.

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DiscoverConceptDetailScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DiscoverConceptDetailScreen.kt
@@ -10,22 +10,24 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.verticalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.concepts_and_quizzes.cds.core.theme.Dimens
@@ -34,39 +36,49 @@ import com.concepts_and_quizzes.cds.core.theme.Dimens
 fun DiscoverConceptDetailScreen(nav: NavHostController, vm: DiscoverConceptViewModel = hiltViewModel()) {
     val concept by vm.concept.collectAsState()
     val bookmarked by vm.bookmarked.collectAsState()
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     concept?.let { c ->
-        ModalBottomSheet(
-            onDismissRequest = { nav.navigateUp() },
-            sheetState = sheetState,
-            containerColor = MaterialTheme.colorScheme.background,
-            tonalElevation = 3.dp,
-            shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
-        ) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = Icons.Filled.Lightbulb,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(c.title)
+                        }
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = { nav.navigateUp() }) {
+                            Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    },
+                    actions = {
+                        IconToggleButton(
+                            checked = bookmarked,
+                            onCheckedChange = { vm.toggleBookmark() }
+                        ) {
+                            Icon(
+                                imageVector = if (bookmarked) Icons.Filled.Star else Icons.Outlined.StarBorder,
+                                contentDescription = null,
+                                tint = if (bookmarked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+                )
+            }
+        ) { padding ->
             Column(
                 modifier = Modifier
+                    .padding(padding)
                     .padding(horizontal = Dimens.SheetPaddingX, vertical = Dimens.SheetPaddingTop)
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(Dimens.ParagraphSpacing)
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(c.title, style = MaterialTheme.typography.headlineSmall)
-                    IconToggleButton(
-                        checked = bookmarked,
-                        onCheckedChange = { vm.toggleBookmark() }
-                    ) {
-                        Icon(
-                            imageVector = if (bookmarked) Icons.Filled.Star else Icons.Outlined.StarBorder,
-                            contentDescription = null,
-                            tint = if (bookmarked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                }
                 val paragraphs = c.detail.split("\n\n")
                 paragraphs.forEach { StyledParagraph(it) }
                 val bullets = emptyList<String>()


### PR DESCRIPTION
## Summary
- show discover tips on a full screen instead of bottom sheet
- add lightbulb icon and bookmark toggle in top app bar
- document new tip screen in codebase overview

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689491650bdc8329973be50b488a8aff