### PR TITLE
Improve bookmark tint and chip label wrapping

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
@@ -51,7 +52,16 @@ fun AnalysisScreen(
     Box {
         FlowRow(horizontalArrangement = spacedBy(8.dp)) {
             report.suggestions.forEach {
-                AssistChip(onClick = { }, label = { Text(it) })
+                AssistChip(
+                    onClick = { },
+                    label = {
+                        Text(
+                            it,
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                )
             }
         }
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/DiscoverComponents.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/DiscoverComponents.kt
@@ -65,7 +65,12 @@ fun DiscoverCard(
                 ) {
                     Icon(
                         imageVector = if (bookmarked) Icons.Filled.Star else Icons.Outlined.StarBorder,
-                        contentDescription = null
+                        contentDescription = null,
+                        tint = if (bookmarked) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        }
                     )
                 }
             }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DiscoverConceptDetailScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/discover/DiscoverConceptDetailScreen.kt
@@ -68,7 +68,11 @@ fun DiscoverConceptDetailScreen(nav: NavHostController, vm: DiscoverConceptViewM
                             Icon(
                                 imageVector = if (bookmarked) Icons.Filled.Star else Icons.Outlined.StarBorder,
                                 contentDescription = null,
-                                tint = if (bookmarked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                                tint = if (bookmarked) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                }
                             )
                         }
                     }


### PR DESCRIPTION
## Summary
- Ensure bookmark stars use onSurfaceVariant when unselected for better dark mode contrast
- Allow long suggestion chips to wrap and ellipsize after three lines

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894943244888329810b814a0b7cb03d