### PR TITLE
Fix AnalyticsUnlocker injection

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlockModule.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlockModule.kt
@@ -1,0 +1,15 @@
+package com.concepts_and_quizzes.cds.data.analytics.unlock
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AnalyticsUnlockModule {
+    @Provides
+    @Singleton
+    fun provideAnalyticsUnlockConfig(): AnalyticsUnlockConfig = AnalyticsUnlockConfig()
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlocker.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlocker.kt
@@ -35,8 +35,10 @@ data class UnlockStats(
 
 /** Computes [ModuleStatus] for all [AnalyticsModule]s. */
 class AnalyticsUnlocker @javax.inject.Inject constructor(
-    private val config: AnalyticsUnlockConfig = AnalyticsUnlockConfig()
+    private val config: AnalyticsUnlockConfig
 ) {
+    constructor() : this(AnalyticsUnlockConfig())
+
     fun statuses(stats: UnlockStats, nowMillis: Long = System.currentTimeMillis()): List<ModuleStatus> {
         val res = mutableListOf<ModuleStatus>()
 


### PR DESCRIPTION
## Summary
- avoid multiple injected constructors in `AnalyticsUnlocker`
- provide Hilt module for `AnalyticsUnlockConfig`

## Testing
- `./gradlew assembleDebug`
- `./gradlew test` *(fails: `NonExistentClass` annotation could not be converted)*

------
https://chatgpt.com/codex/tasks/task_e_6894a0c3f24883298a2dd9c618061e88