### PR TITLE
feat(nav): auto-open analysis screen after quiz submission

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
@@ -1,5 +1,8 @@
 package com.concepts_and_quizzes.cds.core.navigation
 
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -9,6 +12,8 @@ import com.concepts_and_quizzes.cds.ui.english.concepts.ConceptDetailScreen
 import com.concepts_and_quizzes.cds.ui.english.concepts.ConceptsHomeScreen
 import com.concepts_and_quizzes.cds.ui.english.dashboard.EnglishDashboardScreen
 import com.concepts_and_quizzes.cds.ui.english.discover.DiscoverConceptDetailScreen
+import com.concepts_and_quizzes.cds.ui.english.analysis.AnalysisScreen
+import com.concepts_and_quizzes.cds.ui.english.analysis.AnalysisViewModel
 import com.concepts_and_quizzes.cds.ui.english.quiz.QuizHubScreen
 import com.concepts_and_quizzes.cds.ui.english.pyqp.PyqpPaperListScreen
 import com.concepts_and_quizzes.cds.ui.english.pyqp.PyqAnalyticsScreen
@@ -55,5 +60,13 @@ fun NavGraphBuilder.rootGraph(nav: NavHostController) {
     ) { back ->
         val pid = back.arguments?.getString("paperId") ?: return@composable
         PyqpQuizScreen(pid, nav)
+    }
+    composable(
+        route = "analysis/{sessionId}",
+        arguments = listOf(navArgument("sessionId") { type = NavType.StringType })
+    ) {
+        val vm: AnalysisViewModel = hiltViewModel()
+        val report by vm.report.collectAsState()
+        report?.let { AnalysisScreen(it, vm.prefs) }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisViewModel.kt
@@ -1,0 +1,30 @@
+package com.concepts_and_quizzes.cds.ui.english.analysis
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReport
+import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReportRepository
+import com.concepts_and_quizzes.cds.data.settings.UserPreferences
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class AnalysisViewModel @Inject constructor(
+    private val repo: QuizReportRepository,
+    val prefs: UserPreferences,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    private val sessionId: String = checkNotNull(savedStateHandle["sessionId"])
+    private val _report = MutableStateFlow<QuizReport?>(null)
+    val report: StateFlow<QuizReport?> = _report
+
+    init {
+        viewModelScope.launch {
+            _report.value = repo.analyse(sessionId)
+        }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.NavController
 import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
 import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
 import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReportRepository
@@ -366,6 +367,13 @@ class QuizViewModel @Inject constructor(
                     PyqpProgress(paperId = quizId, correct = correct, attempted = questions.size)
                 )
             }
+        }
+    }
+
+    fun onSubmitSuccess(navController: NavController) {
+        navController.navigate("analysis/$sessionId") {
+            popUpTo("practice") { inclusive = false }
+            launchSingleTop = true
         }
     }
 


### PR DESCRIPTION
## Summary
- route quiz submissions to per-session analysis screen
- wire analysis destination into main nav graph with viewmodel
- add viewmodel to load quiz reports

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.concepts_and_quizzes.cds.QuizSubmitNavigationTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894cf52272483298f226ddec1c93cb3