### PR TITLE
feat(nav): add Reports tab controlled by RC flag

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.robolectric)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.ui.test.junit4)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/MainActivity.kt
@@ -18,22 +18,23 @@ import com.concepts_and_quizzes.cds.core.components.CdsBottomNavBar
 import com.concepts_and_quizzes.cds.core.navigation.rootGraph
 import com.concepts_and_quizzes.cds.core.theme.CDSTheme
 import com.concepts_and_quizzes.cds.ui.onboarding.OnboardingScreen
+import com.concepts_and_quizzes.cds.core.config.RemoteConfig
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject lateinit var remoteConfig: RemoteConfig
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         setTheme(R.style.Theme_CDS)
         super.onCreate(savedInstanceState)
-        setContent {
-            CDSApp()
-        }
+        setContent { CDSApp(remoteConfig) }
     }
 }
 
 @Composable
-private fun CDSApp() {
+private fun CDSApp(remoteConfig: RemoteConfig) {
     CDSTheme {
         val appVm: AppViewModel = hiltViewModel()
         val showOnboarding by appVm.showOnboarding.collectAsState()
@@ -48,11 +49,12 @@ private fun CDSApp() {
                 "english/concepts",
                 "quizHub",
                 "english/pyqp?mode={mode}&topic={topic}",
-                "analytics/pyq"
+                "analytics/pyq",
+                "reports"
             )
             val showBottomBar = currentRoute in bottomBarRoutes
 
-            Scaffold(bottomBar = { if (showBottomBar) CdsBottomNavBar(navController) }) { padding ->
+            Scaffold(bottomBar = { if (showBottomBar) CdsBottomNavBar(navController, remoteConfig) }) { padding ->
                 NavHost(
                     navController = navController,
                     startDestination = "english/dashboard",

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/components/NavigationRail.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/components/NavigationRail.kt
@@ -1,8 +1,8 @@
 package com.concepts_and_quizzes.cds.core.components
 
 import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
@@ -13,14 +13,14 @@ import com.concepts_and_quizzes.cds.core.config.RemoteConfig
 import com.concepts_and_quizzes.cds.core.navigation.BottomBarDestination
 
 @Composable
-fun CdsBottomNavBar(
+fun CdsNavigationRail(
     navController: NavHostController,
     remoteConfig: RemoteConfig
 ) {
     val items = BottomBarDestination.entries.filter {
         it != BottomBarDestination.Reports || remoteConfig.getBoolean("reports_tab_enabled")
     }
-    NavigationBar {
+    NavigationRail {
         val navBackStackEntry = navController.currentBackStackEntryAsState().value
         val currentRoute = navBackStackEntry?.destination?.route
         items.forEach { item ->
@@ -32,7 +32,7 @@ fun CdsBottomNavBar(
                     currentRoute?.startsWith("analytics") == true
                 BottomBarDestination.Reports -> currentRoute == "reports"
             }
-            NavigationBarItem(
+            NavigationRailItem(
                 selected = selected,
                 onClick = {
                     navController.navigate(item.route) {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/config/RemoteConfig.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/config/RemoteConfig.kt
@@ -1,0 +1,13 @@
+package com.concepts_and_quizzes.cds.core.config
+
+import javax.inject.Inject
+
+/** Simple interface for remote configuration flags. */
+interface RemoteConfig {
+    fun getBoolean(key: String): Boolean
+}
+
+/** Default implementation always returns true for all flags. */
+class DefaultRemoteConfig @Inject constructor() : RemoteConfig {
+    override fun getBoolean(key: String): Boolean = true
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/config/RemoteConfigModule.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/config/RemoteConfigModule.kt
@@ -1,0 +1,15 @@
+package com.concepts_and_quizzes.cds.core.config
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RemoteConfigModule {
+    @Provides
+    @Singleton
+    fun provideRemoteConfig(): RemoteConfig = DefaultRemoteConfig()
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/BottomBarDestinations.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/BottomBarDestinations.kt
@@ -1,0 +1,22 @@
+package com.concepts_and_quizzes.cds.core.navigation
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.outlined.BarChart
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.concepts_and_quizzes.cds.R
+
+/** Destinations displayed in the bottom navigation and navigation rail. */
+enum class BottomBarDestination(
+    val route: String,
+    val icon: ImageVector,
+    @StringRes val label: Int
+) {
+    Dashboard("english/dashboard", Icons.Filled.Home, R.string.dashboard),
+    Concepts("english/concepts", Icons.AutoMirrored.Filled.MenuBook, R.string.concepts),
+    Quiz("quizHub", Icons.Filled.Edit, R.string.quiz),
+    Reports("reports", Icons.Outlined.BarChart, R.string.reports)
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
@@ -19,6 +19,7 @@ import com.concepts_and_quizzes.cds.ui.english.pyqp.PyqpPaperListScreen
 import com.concepts_and_quizzes.cds.ui.english.pyqp.PyqAnalyticsScreen
 import com.concepts_and_quizzes.cds.ui.analytics.AnalyticsCatalogueScreen
 import com.concepts_and_quizzes.cds.ui.analytics.PlaceholderAnalyticsScreen
+import com.concepts_and_quizzes.cds.ui.reports.ReportsPagerScreen
 import com.concepts_and_quizzes.cds.ui.english.pyqp.QuizScreen as PyqpQuizScreen
 
 fun NavGraphBuilder.rootGraph(nav: NavHostController) {
@@ -54,6 +55,7 @@ fun NavGraphBuilder.rootGraph(nav: NavHostController) {
     composable("analytics/heatmap") { PlaceholderAnalyticsScreen("Topic Heat-map", nav) }
     composable("analytics/peer") { PlaceholderAnalyticsScreen("Peer Percentile", nav) }
     composable("analytics/time") { PlaceholderAnalyticsScreen("Time Management", nav) }
+    composable("reports") { ReportsPagerScreen() }
     composable(
         route = "english/pyqp/{paperId}",
         arguments = listOf(navArgument("paperId") { type = NavType.StringType })

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsPagerScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsPagerScreen.kt
@@ -1,0 +1,9 @@
+package com.concepts_and_quizzes.cds.ui.reports
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ReportsPagerScreen() {
+    Text("Reports placeholder")
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,8 @@
     <string name="sign_out">Sign out</string>
     <!-- Placeholder client ID used for development builds -->
     <string name="default_web_client_id">YOUR_WEB_CLIENT_ID</string>
+    <string name="dashboard">Dashboard</string>
+    <string name="concepts">Concepts</string>
+    <string name="quiz">Quiz</string>
+    <string name="reports">Reports</string>
 </resources>

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/main/BottomBarVisibilityTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/main/BottomBarVisibilityTest.kt
@@ -1,0 +1,40 @@
+package com.concepts_and_quizzes.cds.ui.main
+
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.navigation.compose.rememberNavController
+import com.concepts_and_quizzes.cds.core.components.CdsBottomNavBar
+import com.concepts_and_quizzes.cds.core.config.RemoteConfig
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BottomBarVisibilityTest {
+    @get:Rule val composeRule = createComposeRule()
+
+    @Test
+    fun reportsTabVisibleWhenFlagTrue() {
+        val rc = object : RemoteConfig {
+            override fun getBoolean(key: String) = true
+        }
+        composeRule.setContent {
+            CdsBottomNavBar(rememberNavController(), rc)
+        }
+        composeRule.onNodeWithText("Reports").assertExists()
+    }
+
+    @Test
+    fun reportsTabHiddenWhenFlagFalse() {
+        val rc = object : RemoteConfig {
+            override fun getBoolean(key: String) = false
+        }
+        composeRule.setContent {
+            CdsBottomNavBar(rememberNavController(), rc)
+        }
+        composeRule.onNodeWithText("Reports").assertDoesNotExist()
+    }
+}


### PR DESCRIPTION
## Summary
- add BottomBarDestination enum with Reports entry
- gate BottomNavBar and NavigationRail items behind RemoteConfig flag
- add reports route and placeholder screen

## Testing
- `./gradlew :app:verifyPaparazziDebug` *(fails: Cannot locate task)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d8c004308329a933304f63d189b9