### PR TITLE
feat(reports): vertical pager skeleton with 5 pages

### DIFF
--- a/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/ReportsSwipeTest.kt
+++ b/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/ReportsSwipeTest.kt
@@ -1,0 +1,33 @@
+package com.concepts_and_quizzes.cds.ui.reports
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeDown
+import androidx.compose.ui.test.swipeUp
+import org.junit.Rule
+import org.junit.Test
+
+class ReportsSwipeTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun swipeUpAndDownChangesPage() {
+        composeTestRule.setContent { ReportsPagerScreen() }
+
+        composeTestRule.onNodeWithText("Last Quiz").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("reportsPager")
+            .performTouchInput { swipeUp() }
+        composeTestRule.onNodeWithText("Trend").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("reportsPager")
+            .performTouchInput { swipeDown() }
+        composeTestRule.onNodeWithText("Last Quiz").assertIsDisplayed()
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsPagerScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsPagerScreen.kt
@@ -1,9 +1,65 @@
 package com.concepts_and_quizzes.cds.ui.reports
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 
 @Composable
-fun ReportsPagerScreen() {
-    Text("Reports placeholder")
+fun ReportsPagerScreen(startPage: Int = 0) {
+    val pagerState = rememberPagerState(initialPage = startPage)
+    VerticalPager(
+        count = 5,
+        state = pagerState,
+        modifier = Modifier.testTag("reportsPager")
+    ) { page ->
+        when (page) {
+            0 -> LastQuizPage()
+            1 -> TrendPagePlaceholder()
+            2 -> HeatMapPlaceholder()
+            3 -> TimeMgmtPlaceholder()
+            4 -> PeerPlaceholder()
+        }
+    }
 }
+
+@Composable
+fun LastQuizPage() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Last Quiz")
+    }
+}
+
+@Composable
+fun TrendPagePlaceholder() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Trend")
+    }
+}
+
+@Composable
+fun HeatMapPlaceholder() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Heat Map")
+    }
+}
+
+@Composable
+fun TimeMgmtPlaceholder() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Time Mgmt")
+    }
+}
+
+@Composable
+fun PeerPlaceholder() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Peer")
+    }
+}
+


### PR DESCRIPTION
## Summary
- scaffold reports view with vertical pager and placeholder pages
- add UI test checking that vertical swipes navigate between pages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894dbd451cc83298178bc4b9580989e