### PR TITLE
feat(reports): embed QuizAnalysisScreen as first pager page

### DIFF
--- a/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/ReportsSwipeTest.kt
+++ b/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/ReportsSwipeTest.kt
@@ -19,7 +19,7 @@ class ReportsSwipeTest {
     fun swipeUpAndDownChangesPage() {
         composeTestRule.setContent { ReportsPagerScreen() }
 
-        composeTestRule.onNodeWithText("Last Quiz").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No reports").assertIsDisplayed()
 
         composeTestRule.onNodeWithTag("reportsPager")
             .performTouchInput { swipeUp() }
@@ -27,7 +27,7 @@ class ReportsSwipeTest {
 
         composeTestRule.onNodeWithTag("reportsPager")
             .performTouchInput { swipeDown() }
-        composeTestRule.onNodeWithText("Last Quiz").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No reports").assertIsDisplayed()
     }
 }
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
@@ -19,6 +19,7 @@ import com.concepts_and_quizzes.cds.ui.english.pyqp.PyqpPaperListScreen
 import com.concepts_and_quizzes.cds.ui.english.pyqp.PyqAnalyticsScreen
 import com.concepts_and_quizzes.cds.ui.analytics.AnalyticsCatalogueScreen
 import com.concepts_and_quizzes.cds.ui.analytics.PlaceholderAnalyticsScreen
+import com.concepts_and_quizzes.cds.ui.reports.ReportsNavArgs
 import com.concepts_and_quizzes.cds.ui.reports.ReportsPagerScreen
 import com.concepts_and_quizzes.cds.ui.english.pyqp.QuizScreen as PyqpQuizScreen
 
@@ -55,7 +56,13 @@ fun NavGraphBuilder.rootGraph(nav: NavHostController) {
     composable("analytics/heatmap") { PlaceholderAnalyticsScreen("Topic Heat-map", nav) }
     composable("analytics/peer") { PlaceholderAnalyticsScreen("Peer Percentile", nav) }
     composable("analytics/time") { PlaceholderAnalyticsScreen("Time Management", nav) }
-    composable("reports") { ReportsPagerScreen() }
+    composable(
+        route = "reports?analysisSessionId={analysisSessionId}",
+        arguments = listOf(navArgument("analysisSessionId") { type = NavType.StringType; nullable = true })
+    ) { backStack ->
+        val sid = backStack.arguments?.getString("analysisSessionId")
+        ReportsPagerScreen(navArgs = ReportsNavArgs(sid))
+    }
     composable(
         route = "english/pyqp/{paperId}",
         arguments = listOf(navArgument("paperId") { type = NavType.StringType })

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/QuizTraceDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/QuizTraceDao.kt
@@ -13,4 +13,7 @@ interface QuizTraceDao {
 
     @Query("SELECT * FROM quiz_trace WHERE sessionId = :sid")
     suspend fun tracesForSession(sid: String): List<QuizTrace>
+
+    @Query("SELECT sessionId FROM quiz_trace ORDER BY answeredAt DESC LIMIT 1")
+    suspend fun latestSessionId(): String?
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/QuizReportRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/QuizReportRepository.kt
@@ -14,4 +14,6 @@ class QuizReportRepository @Inject constructor(
         val traces = dao.tracesForSession(sessionId)
         return QuizReportBuilder(traces).build()
     }
+
+    suspend fun latestSessionId(): String? = dao.latestSessionId()
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -371,7 +371,7 @@ class QuizViewModel @Inject constructor(
     }
 
     fun onSubmitSuccess(navController: NavController) {
-        navController.navigate("analysis/$sessionId") {
+        navController.navigate("reports?analysisSessionId=$sessionId") {
             popUpTo("practice") { inclusive = false }
             launchSingleTop = true
         }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizViewModel.kt
@@ -1,0 +1,29 @@
+package com.concepts_and_quizzes.cds.ui.reports
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReport
+import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReportRepository
+import com.concepts_and_quizzes.cds.data.settings.UserPreferences
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class LastQuizViewModel @Inject constructor(
+    private val repo: QuizReportRepository,
+    val prefs: UserPreferences,
+) : ViewModel() {
+    private val _report = MutableStateFlow<QuizReport?>(null)
+    val report: StateFlow<QuizReport?> = _report
+
+    fun load(sessionId: String?) {
+        viewModelScope.launch {
+            val sid = sessionId ?: repo.latestSessionId() ?: return@launch
+            _report.value = repo.analyse(sid)
+        }
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsNavArgs.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsNavArgs.kt
@@ -1,0 +1,6 @@
+package com.concepts_and_quizzes.cds.ui.reports
+
+data class ReportsNavArgs(
+    val analysisSessionId: String? = null
+)
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsPagerScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsPagerScreen.kt
@@ -6,12 +6,20 @@ import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.concepts_and_quizzes.cds.ui.english.analysis.AnalysisScreen
 
 @Composable
-fun ReportsPagerScreen(startPage: Int = 0) {
+fun ReportsPagerScreen(
+    navArgs: ReportsNavArgs = ReportsNavArgs(),
+    startPage: Int = 0,
+) {
     val pagerState = rememberPagerState(initialPage = startPage)
     VerticalPager(
         count = 5,
@@ -19,7 +27,7 @@ fun ReportsPagerScreen(startPage: Int = 0) {
         modifier = Modifier.testTag("reportsPager")
     ) { page ->
         when (page) {
-            0 -> LastQuizPage()
+            0 -> LastQuizPage(navArgs.analysisSessionId)
             1 -> TrendPagePlaceholder()
             2 -> HeatMapPlaceholder()
             3 -> TimeMgmtPlaceholder()
@@ -29,9 +37,12 @@ fun ReportsPagerScreen(startPage: Int = 0) {
 }
 
 @Composable
-fun LastQuizPage() {
+fun LastQuizPage(sessionId: String?) {
+    val vm: LastQuizViewModel = hiltViewModel()
+    LaunchedEffect(sessionId) { vm.load(sessionId) }
+    val report by vm.report.collectAsState()
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Last Quiz")
+        report?.let { AnalysisScreen(it, vm.prefs) } ?: Text("No reports")
     }
 }
 

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizSubmitNavigationTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizSubmitNavigationTest.kt
@@ -1,0 +1,107 @@
+package com.concepts_and_quizzes.cds.ui.english.pyqp
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.test.core.app.ApplicationProvider
+import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
+import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
+import com.concepts_and_quizzes.cds.data.analytics.db.TopicDifficultyDb
+import com.concepts_and_quizzes.cds.data.analytics.db.TopicTrendPointDb
+import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
+import com.concepts_and_quizzes.cds.data.analytics.db.TrendPoint
+import com.concepts_and_quizzes.cds.data.analytics.db.QuizTrace
+import com.concepts_and_quizzes.cds.data.analytics.db.QuizTraceDao
+import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReportRepository
+import com.concepts_and_quizzes.cds.data.english.db.PyqpDao
+import com.concepts_and_quizzes.cds.data.english.db.PyqpProgressDao
+import com.concepts_and_quizzes.cds.data.english.model.PyqpProgress
+import com.concepts_and_quizzes.cds.data.english.model.PyqpQuestionEntity
+import com.concepts_and_quizzes.cds.data.english.repo.PyqpRepository
+import com.concepts_and_quizzes.cds.data.quiz.QuizResumeStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class QuizSubmitNavigationTest {
+    @Before
+    fun setUp() {
+        kotlinx.coroutines.Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        kotlinx.coroutines.Dispatchers.resetMain()
+    }
+
+    @Test
+    fun navigatesToReportsPage() = runTest {
+        val dao = object : PyqpDao {
+            override suspend fun insertAll(questions: List<PyqpQuestionEntity>) {}
+            override fun getDistinctPaperIds(): Flow<List<String>> = flowOf(emptyList())
+            override fun getQuestionsByPaper(paperId: String): Flow<List<PyqpQuestionEntity>> = flowOf(emptyList())
+            override suspend fun getQuestionsByIds(qids: List<String>): List<PyqpQuestionEntity> = emptyList()
+            override suspend fun count(): Int = 0
+        }
+        val progressDao = object : PyqpProgressDao {
+            override suspend fun upsert(progress: PyqpProgress) {}
+            override fun getAll(): Flow<List<PyqpProgress>> = MutableStateFlow(emptyList())
+        }
+        val attemptDao = object : AttemptLogDao {
+            override suspend fun insertAll(attempts: List<AttemptLogEntity>) {}
+            override suspend fun latestWrongQids(topicId: String): List<String> = emptyList()
+            override fun getTrend(startTime: Long): Flow<List<TopicTrendPointDb>> = flowOf(emptyList())
+            override fun getDifficulty(): Flow<List<TopicDifficultyDb>> = flowOf(emptyList())
+            override fun getAttemptsWithScore(): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptWithScoreDb>> =
+                flowOf(emptyList())
+        }
+        val topicStatDao = object : com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao {
+            override fun topicSnapshot(cutoffTime: Long): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.TopicStat>> =
+                flowOf(emptyList())
+            override fun trendSnapshot(cutoffTime: Long): Flow<List<TrendPoint>> = flowOf(emptyList())
+        }
+        val analytics = AnalyticsRepository(attemptDao, topicStatDao)
+        val repo = PyqpRepository(dao, attemptDao)
+        val traceDao = object : QuizTraceDao {
+            override suspend fun insertTrace(trace: QuizTrace) {}
+            override suspend fun tracesForSession(sid: String): List<QuizTrace> = emptyList()
+            override suspend fun latestSessionId(): String? = null
+        }
+        val reportRepo = QuizReportRepository(traceDao)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val vm = QuizViewModel(
+            repo,
+            progressDao,
+            analytics,
+            reportRepo,
+            QuizResumeStore(context),
+            SavedStateHandle(mapOf("paperId" to "paper"))
+        )
+        advanceUntilIdle()
+
+        val nav = object : NavHostController(context) {
+            var route: String? = null
+            override fun navigate(route: String, navOptions: NavOptions?, navigatorExtras: Navigator.Extras?) {
+                this.route = route
+            }
+        }
+
+        vm.onSubmitSuccess(nav)
+        assertTrue(nav.route!!.startsWith("reports?analysisSessionId="))
+    }
+}
+

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
@@ -84,6 +84,7 @@ class QuizViewModelTest {
         val traceDao = object : QuizTraceDao {
             override suspend fun insertTrace(trace: QuizTrace) { traces.add(trace) }
             override suspend fun tracesForSession(sid: String): List<QuizTrace> = traces.filter { it.sessionId == sid }
+            override suspend fun latestSessionId(): String? = traces.maxByOrNull { it.answeredAt }?.sessionId
         }
         val reportRepo = QuizReportRepository(traceDao)
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -143,6 +144,7 @@ class QuizViewModelTest {
         val traceDao = object : QuizTraceDao {
             override suspend fun insertTrace(trace: QuizTrace) {}
             override suspend fun tracesForSession(sid: String): List<QuizTrace> = emptyList()
+            override suspend fun latestSessionId(): String? = null
         }
         val reportRepo = QuizReportRepository(traceDao)
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -187,6 +189,7 @@ class QuizViewModelTest {
         val traceDao = object : QuizTraceDao {
             override suspend fun insertTrace(trace: QuizTrace) {}
             override suspend fun tracesForSession(sid: String): List<QuizTrace> = emptyList()
+            override suspend fun latestSessionId(): String? = null
         }
         val reportRepo = QuizReportRepository(traceDao)
         val context = ApplicationProvider.getApplicationContext<Context>()


### PR DESCRIPTION
## Summary
- Wire new reports route with optional analysis session id argument
- Load quiz analysis as first page in ReportsPager using LastQuizViewModel
- Navigate to reports page after quiz submission

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894de653ee883298937bc975f75cbfe