### PR TITLE
chore(reports): placeholder pages for upcoming analytics modules

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsPagerScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsPagerScreen.kt
@@ -14,6 +14,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.concepts_and_quizzes.cds.ui.reports.trend.TrendPage
+import com.concepts_and_quizzes.cds.ui.reports.heatmap.HeatMapPage
+import com.concepts_and_quizzes.cds.ui.reports.time.TimePage
+import com.concepts_and_quizzes.cds.ui.reports.peer.PeerPage
 import com.concepts_and_quizzes.cds.ui.english.analysis.AnalysisScreen
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -29,10 +33,10 @@ fun ReportsPagerScreen(
     ) { page ->
         when (page) {
             0 -> LastQuizPage(navArgs.analysisSessionId)
-            1 -> TrendPagePlaceholder()
-            2 -> HeatMapPlaceholder()
-            3 -> TimeMgmtPlaceholder()
-            4 -> PeerPlaceholder()
+            1 -> TrendPage()
+            2 -> HeatMapPage()
+            3 -> TimePage()
+            4 -> PeerPage()
         }
     }
 }
@@ -47,31 +51,4 @@ fun LastQuizPage(sessionId: String?) {
     }
 }
 
-@Composable
-fun TrendPagePlaceholder() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Trend")
-    }
-}
-
-@Composable
-fun HeatMapPlaceholder() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Heat Map")
-    }
-}
-
-@Composable
-fun TimeMgmtPlaceholder() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Time Mgmt")
-    }
-}
-
-@Composable
-fun PeerPlaceholder() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Peer")
-    }
-}
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
@@ -1,0 +1,23 @@
+package com.concepts_and_quizzes.cds.ui.reports.heatmap
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class HeatMapViewModel @Inject constructor() : ViewModel()
+
+@Composable
+fun HeatMapPage(vm: HeatMapViewModel = hiltViewModel()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Heat Map")
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
@@ -1,0 +1,23 @@
+package com.concepts_and_quizzes.cds.ui.reports.peer
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class PeerViewModel @Inject constructor() : ViewModel()
+
+@Composable
+fun PeerPage(vm: PeerViewModel = hiltViewModel()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Peer")
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
@@ -1,0 +1,23 @@
+package com.concepts_and_quizzes.cds.ui.reports.time
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class TimeViewModel @Inject constructor() : ViewModel()
+
+@Composable
+fun TimePage(vm: TimeViewModel = hiltViewModel()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Time")
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
@@ -1,0 +1,23 @@
+package com.concepts_and_quizzes.cds.ui.reports.trend
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class TrendViewModel @Inject constructor() : ViewModel()
+
+@Composable
+fun TrendPage(vm: TrendViewModel = hiltViewModel()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Trend")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add stubbed Trend, Heat Map, Time, and Peer report pages with hilt ViewModels
- wire new pages into the reports pager

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955d5d2aa48329a6f773158f3129a4