### PR TITLE
feat(theme): add flaggedContainer colors and apply in quiz palette

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/ColorSchemeExt.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/ColorSchemeExt.kt
@@ -15,3 +15,13 @@ val ColorScheme.flaggedContainer: Color
     } else {
         primary.copy(alpha = 0.20f)
     }
+
+/** Text color displayed on [flaggedContainer]. */
+val ColorScheme.flaggedOnContainer: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = if (isSystemInDarkTheme()) {
+        Color(0xFFCAE5FF)
+    } else {
+        Color(0xFF00315D)
+    }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionLegend.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionLegend.kt
@@ -1,0 +1,54 @@
+package com.concepts_and_quizzes.cds.ui.quiz
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun QuestionLegend(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        LegendChip(
+            MaterialTheme.colorScheme.primaryContainer,
+            MaterialTheme.colorScheme.onPrimaryContainer,
+            "Answered"
+        )
+        LegendChip(
+            MaterialTheme.colorScheme.flaggedContainer,
+            MaterialTheme.colorScheme.flaggedOnContainer,
+            "Flagged"
+        )
+        LegendChip(
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant,
+            "Not Answered"
+        )
+    }
+}
+
+@Composable
+private fun LegendChip(
+    containerColor: Color,
+    contentColor: Color,
+    label: String
+) {
+    Surface(
+        color = containerColor,
+        contentColor = contentColor,
+        shape = RoundedCornerShape(4.dp)
+    ) {
+        Text(label, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp))
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionStatePalette.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionStatePalette.kt
@@ -1,0 +1,80 @@
+package com.concepts_and_quizzes.cds.ui.quiz
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Dialog showing a grid of question numbers with state colours.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun QuestionStatePalette(
+    entries: List<QuestionStatePaletteEntry>,
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {},
+        title = { Text("Jump to question") },
+        text = {
+            Column {
+                QuestionLegend()
+                Spacer(Modifier.height(8.dp))
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(5),
+                    modifier = Modifier.height(200.dp)
+                ) {
+                    items(entries, key = { it.questionIndex }) { e ->
+                        val (container, content) = when {
+                            e.flagged && !e.answered ->
+                                MaterialTheme.colorScheme.flaggedContainer to MaterialTheme.colorScheme.flaggedOnContainer
+                            e.flagged ->
+                                MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
+                            e.answered ->
+                                MaterialTheme.colorScheme.primaryContainer to MaterialTheme.colorScheme.onPrimaryContainer
+                            else ->
+                                MaterialTheme.colorScheme.surfaceVariant to MaterialTheme.colorScheme.onSurfaceVariant
+                        }
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center,
+                            modifier = Modifier
+                                .padding(4.dp)
+                                .background(container, RoundedCornerShape(8.dp))
+                                .clickable { onSelect(e.questionIndex) }
+                                .height(48.dp)
+                                .fillMaxWidth()
+                        ) {
+                            Text("${e.questionIndex + 1}", color = content)
+                        }
+                    }
+                }
+            }
+        }
+    )
+}
+
+data class QuestionStatePaletteEntry(
+    val questionIndex: Int,
+    val answered: Boolean,
+    val flagged: Boolean
+)


### PR DESCRIPTION
## Summary
- add flaggedContainer and flaggedOnContainer tokens to theme
- style quiz legend and palette to use new flag colours

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955f2479cc832993b5d7f287a12113