### PR TITLE
feat(theme): add flaggedContainer colors and apply in quiz palette

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/ColorSchemeExt.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/theme/ColorSchemeExt.kt
@@ -15,3 +15,12 @@ val ColorScheme.flaggedContainer: Color
     } else {
         primary.copy(alpha = 0.20f)
     }
+
+val ColorScheme.flaggedOnContainer: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = if (isSystemInDarkTheme()) {
+        Color(0xFFCAE5FF)
+    } else {
+        Color(0xFF00315D)
+    }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.background
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.RoundedCornerShape
 import android.app.Activity
 import android.os.SystemClock
@@ -40,7 +38,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.navigation.NavController
 import com.concepts_and_quizzes.cds.domain.english.PyqpQuestion
 import kotlinx.coroutines.launch
-import com.concepts_and_quizzes.cds.core.theme.flaggedContainer
+import com.concepts_and_quizzes.cds.ui.quiz.QuestionStatePalette
 
 @Composable
 fun QuizScreen(
@@ -241,8 +239,8 @@ private fun QuizPager(vm: QuizViewModel, state: QuizViewModel.QuizUi.Page) {
     }
 
     if (showPalette) {
-        PaletteDialog(
-            vm.questionPalette(),
+        QuestionStatePalette(
+            entries = vm.questionPalette(),
             onSelect = {
                 vm.goToQuestion(it)
                 showPalette = false
@@ -383,66 +381,6 @@ private fun OptionCard(selected: Boolean, text: String, onClick: () -> Unit) {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun PaletteDialog(
-    entries: List<QuizViewModel.PaletteEntry>,
-    onSelect: (Int) -> Unit,
-    onDismiss: () -> Unit
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        confirmButton = {},
-        title = { Text("Jump to question") },
-        text = {
-            Column {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    LegendChip(MaterialTheme.colorScheme.primaryContainer, "Answered")
-                    LegendChip(MaterialTheme.colorScheme.flaggedContainer, "Flagged")
-                    LegendChip(MaterialTheme.colorScheme.surfaceVariant, "Not Answered")
-                }
-                Spacer(Modifier.height(8.dp))
-                LazyVerticalGrid(columns = GridCells.Fixed(5), modifier = Modifier.heightIn(max = 200.dp)) {
-                    items(entries.size) { idx ->
-                        val e = entries[idx]
-                        val color = when {
-                            e.flagged && !e.answered -> MaterialTheme.colorScheme.flaggedContainer
-                            e.flagged -> MaterialTheme.colorScheme.secondaryContainer
-                            e.answered -> MaterialTheme.colorScheme.primaryContainer
-                            else -> MaterialTheme.colorScheme.surfaceVariant
-                        }
-                        Box(
-                            modifier = Modifier
-                                .padding(4.dp)
-                                .size(48.dp)
-                                .background(color, RoundedCornerShape(8.dp))
-                                .clickable { onSelect(e.questionIndex) },
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text("${e.questionIndex + 1}")
-                        }
-                    }
-                }
-            }
-        }
-    )
-}
-
-@Composable
-private fun LegendChip(color: Color, label: String) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Box(
-            modifier = Modifier
-                .size(12.dp)
-                .background(color, RoundedCornerShape(2.dp))
-        )
-        Spacer(Modifier.width(4.dp))
-        Text(label)
-    }
-}
 
 @Composable
 private fun ResultView(

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionLegend.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionLegend.kt
@@ -1,0 +1,49 @@
+package com.concepts_and_quizzes.cds.ui.quiz
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun QuestionLegend() {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        LegendChip(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            label = "Answered"
+        )
+        LegendChip(
+            containerColor = MaterialTheme.colorScheme.flaggedContainer,
+            contentColor = MaterialTheme.colorScheme.flaggedOnContainer,
+            label = "Flagged"
+        )
+        LegendChip(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            label = "Not Answered"
+        )
+    }
+}
+
+@Composable
+private fun LegendChip(containerColor: Color, contentColor: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(12.dp)
+                .background(containerColor, RoundedCornerShape(2.dp))
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(label, color = contentColor)
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionStatePalette.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionStatePalette.kt
@@ -1,0 +1,66 @@
+package com.concepts_and_quizzes.cds.ui.quiz
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.concepts_and_quizzes.cds.ui.english.pyqp.QuizViewModel
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun QuestionStatePalette(
+    entries: List<QuizViewModel.PaletteEntry>,
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {},
+        title = { Text("Jump to question") },
+        text = {
+            Column {
+                QuestionLegend()
+                Spacer(Modifier.height(8.dp))
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(5),
+                    modifier = Modifier.heightIn(max = 200.dp)
+                ) {
+                    items(entries.size) { idx ->
+                        val e = entries[idx]
+                        val container = when {
+                            e.flagged -> MaterialTheme.colorScheme.flaggedContainer
+                            e.answered -> MaterialTheme.colorScheme.primaryContainer
+                            else -> MaterialTheme.colorScheme.surfaceVariant
+                        }
+                        val content = when {
+                            e.flagged -> MaterialTheme.colorScheme.flaggedOnContainer
+                            e.answered -> MaterialTheme.colorScheme.onPrimaryContainer
+                            else -> MaterialTheme.colorScheme.onSurfaceVariant
+                        }
+                        Box(
+                            modifier = Modifier
+                                .padding(4.dp)
+                                .size(48.dp)
+                                .background(container, RoundedCornerShape(8.dp))
+                                .clickable { onSelect(e.questionIndex) },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text("${e.questionIndex + 1}", color = content)
+                        }
+                    }
+                }
+            }
+        }
+    )
+}

--- a/app/src/test/java/com/concepts_and_quizzes/cds/core/theme/FlagColorContrastTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/core/theme/FlagColorContrastTest.kt
@@ -1,0 +1,44 @@
+package com.concepts_and_quizzes.cds.core.theme
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.luminance
+import kotlin.math.max
+import kotlin.math.min
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FlagColorContrastTest {
+    @Test
+    fun flaggedColorsMeetContrastGuidelines() {
+        val lightScheme = lightColorScheme()
+        val darkScheme = darkColorScheme()
+
+        val lightBg = lightScheme.surface
+        val darkBg = darkScheme.surface
+
+        val lightFlaggedContainer = lightScheme.primary.copy(alpha = 0.20f).compositeOver(lightBg)
+        val darkFlaggedContainer = darkScheme.primaryContainer.copy(alpha = 0.24f).compositeOver(darkBg)
+
+        val lightFlaggedOnContainer = Color(0xFF00315D)
+        val darkFlaggedOnContainer = Color(0xFFCAE5FF)
+
+        assertContrast(lightFlaggedContainer, lightFlaggedOnContainer)
+        assertContrast(darkFlaggedContainer, darkFlaggedOnContainer)
+    }
+
+    private fun assertContrast(a: Color, b: Color) {
+        val ratio = contrastRatio(a, b)
+        assertTrue("Contrast ratio $ratio is below 4.5", ratio >= 4.5f)
+    }
+
+    private fun contrastRatio(a: Color, b: Color): Float {
+        val l1 = a.luminance()
+        val l2 = b.luminance()
+        val lighter = max(l1, l2)
+        val darker = min(l1, l2)
+        return ((lighter + 0.05f) / (darker + 0.05f)).toFloat()
+    }
+}


### PR DESCRIPTION
## Summary
- add flaggedContainer and flaggedOnContainer theme tokens
- introduce QuestionStatePalette and legend using new colors
- wire quiz UI to use new palette

## Testing
- `./gradlew testDebugUnitTest --tests com.concepts_and_quizzes.cds.core.theme.FlagColorContrastTest` *(fails: SDK location not found)*
- `apt-get install -y android-sdk` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_68955f2479cc832993b5d7f287a12113