### PR TITLE
feat(util): pretty duration formatted

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/util/DurationExt.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/util/DurationExt.kt
@@ -1,0 +1,35 @@
+package com.concepts_and_quizzes.cds.util
+
+import kotlin.time.Duration
+
+/**
+ * Returns a human-friendly string representation of this [Duration].
+ *
+ * The output uses day (`d`), hour (`h`), minute (`m`), and second (`s`) units
+ * and omits zero-valued components except when the duration is zero seconds.
+ * Examples:
+ *  - `65.seconds.toPretty()` returns `"1m 5s"`
+ *  - `25.hours.toPretty()` returns `"1d 1h"`
+ */
+fun Duration.toPretty(): String {
+    val totalSeconds = inWholeSeconds
+    var remaining = totalSeconds
+
+    val days = remaining / 86_400
+    remaining %= 86_400
+
+    val hours = remaining / 3_600
+    remaining %= 3_600
+
+    val minutes = remaining / 60
+    val seconds = remaining % 60
+
+    val parts = mutableListOf<String>()
+    if (days > 0) parts += "${days}d"
+    if (hours > 0) parts += "${hours}h"
+    if (minutes > 0) parts += "${minutes}m"
+    if (seconds > 0 || parts.isEmpty()) parts += "${seconds}s"
+
+    return parts.joinToString(" ")
+}
+

--- a/app/src/test/java/com/concepts_and_quizzes/cds/util/CountdownFormatterTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/util/CountdownFormatterTest.kt
@@ -1,0 +1,31 @@
+package com.concepts_and_quizzes.cds.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class CountdownFormatterTest {
+    @Test
+    fun `formats zero seconds`() {
+        assertEquals("0s", Duration.ZERO.toPretty())
+    }
+
+    @Test
+    fun `formats minutes and seconds`() {
+        assertEquals("1m 5s", (1.minutes + 5.seconds).toPretty())
+    }
+
+    @Test
+    fun `formats hours and minutes`() {
+        assertEquals("1h 1m", (1.hours + 1.minutes).toPretty())
+    }
+
+    @Test
+    fun `formats days`() {
+        assertEquals("1d 1h", 25.hours.toPretty())
+    }
+}
+


### PR DESCRIPTION
## Summary
- format kotlin Duration in a human-friendly way
- test countdown formatting for various units

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew ktlintCheck` *(fails: Task 'ktlintCheck' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689562569b40832999ca38d3d80a45d4