### PR TITLE
feat(analytics): progress field & RC override for unlock thresholds

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/config/RemoteConfig.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/config/RemoteConfig.kt
@@ -5,9 +5,11 @@ import javax.inject.Inject
 /** Simple interface for remote configuration flags. */
 interface RemoteConfig {
     fun getBoolean(key: String): Boolean
+    fun getString(key: String): String?
 }
 
 /** Default implementation always returns true for all flags. */
 class DefaultRemoteConfig @Inject constructor() : RemoteConfig {
     override fun getBoolean(key: String): Boolean = true
+    override fun getString(key: String): String? = null
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlockConfig.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlockConfig.kt
@@ -1,0 +1,46 @@
+package com.concepts_and_quizzes.cds.data.analytics.unlock
+
+import com.concepts_and_quizzes.cds.core.config.RemoteConfig
+import javax.inject.Inject
+import org.json.JSONObject
+
+/** Configuration controlling unlock thresholds. */
+class AnalyticsUnlockConfig @Inject constructor(remoteConfig: RemoteConfig) {
+    val trendQuizzes: Int
+    val heatmapQuestions: Int
+    val timeGateHours: Int
+
+    init {
+        val defaults = mapOf(
+            TREND to DEFAULT_TREND,
+            HEATMAP to DEFAULT_HEATMAP,
+            TIME to DEFAULT_TIME
+        )
+        val overrides = remoteConfig.getString(RC_KEY)?.let { parseJson(it) } ?: emptyMap()
+        val merged = defaults + overrides
+        trendQuizzes = merged[TREND] ?: DEFAULT_TREND
+        heatmapQuestions = merged[HEATMAP] ?: DEFAULT_HEATMAP
+        timeGateHours = merged[TIME] ?: DEFAULT_TIME
+    }
+
+    companion object {
+        private const val RC_KEY = "unlock_thresholds_v1"
+        private const val TREND = "trendQuizzes"
+        private const val HEATMAP = "heatmapQuestions"
+        private const val TIME = "timeGateHours"
+        private const val DEFAULT_TREND = 3
+        private const val DEFAULT_HEATMAP = 50
+        private const val DEFAULT_TIME = 24
+
+        private fun parseJson(json: String): Map<String, Int> = try {
+            val obj = JSONObject(json)
+            buildMap {
+                obj.keys().forEach { key ->
+                    put(key, obj.optInt(key))
+                }
+            }
+        } catch (e: Exception) {
+            emptyMap()
+        }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlockModule.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlockModule.kt
@@ -1,5 +1,6 @@
 package com.concepts_and_quizzes.cds.data.analytics.unlock
 
+import com.concepts_and_quizzes.cds.core.config.RemoteConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -11,5 +12,5 @@ import javax.inject.Singleton
 object AnalyticsUnlockModule {
     @Provides
     @Singleton
-    fun provideAnalyticsUnlockConfig(): AnalyticsUnlockConfig = AnalyticsUnlockConfig()
+    fun provideAnalyticsUnlockConfig(rc: RemoteConfig): AnalyticsUnlockConfig = AnalyticsUnlockConfig(rc)
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlocker.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlocker.kt
@@ -1,5 +1,7 @@
 package com.concepts_and_quizzes.cds.data.analytics.unlock
 
+import com.concepts_and_quizzes.cds.core.config.DefaultRemoteConfig
+import kotlin.math.min
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -10,6 +12,7 @@ enum class AnalyticsModule { TREND, HEATMAP, PEER, TIME }
 data class ModuleStatus(
     val module: AnalyticsModule,
     val unlocked: Boolean,
+    val progress: Float,
     val reason: LockedReason? = null
 )
 
@@ -17,14 +20,6 @@ sealed interface LockedReason {
     data class MoreQuizzes(val remaining: Int) : LockedReason
     data class TimeGate(val duration: Duration) : LockedReason
 }
-
-/** Configuration controlling unlock thresholds. */
-data class AnalyticsUnlockConfig(
-    val trendQuizzes: Int = 3,
-    val heatmapQuestions: Int = 50,
-    val timeGateHours: Int = 24
-)
-
 /** Snapshot of quiz stats needed to compute unlock states. */
 data class UnlockStats(
     val sessionsLast7d: Int,
@@ -37,41 +32,54 @@ data class UnlockStats(
 class AnalyticsUnlocker @javax.inject.Inject constructor(
     private val config: AnalyticsUnlockConfig
 ) {
-    constructor() : this(AnalyticsUnlockConfig())
+    constructor() : this(AnalyticsUnlockConfig(DefaultRemoteConfig()))
 
     fun statuses(stats: UnlockStats, nowMillis: Long = System.currentTimeMillis()): List<ModuleStatus> {
         val res = mutableListOf<ModuleStatus>()
 
+        val trendProgress = min(
+            stats.sessionsLast7d / config.trendQuizzes.toFloat(),
+            1f
+        )
         if (stats.sessionsLast7d >= config.trendQuizzes) {
-            res += ModuleStatus(AnalyticsModule.TREND, true)
+            res += ModuleStatus(AnalyticsModule.TREND, true, trendProgress)
         } else {
             res += ModuleStatus(
                 AnalyticsModule.TREND,
                 false,
+                trendProgress,
                 LockedReason.MoreQuizzes(config.trendQuizzes - stats.sessionsLast7d)
             )
         }
 
+        val heatmapProgress = min(
+            stats.answered / config.heatmapQuestions.toFloat(),
+            1f
+        )
         if (stats.answered >= config.heatmapQuestions) {
-            res += ModuleStatus(AnalyticsModule.HEATMAP, true)
+            res += ModuleStatus(AnalyticsModule.HEATMAP, true, heatmapProgress)
         } else {
             res += ModuleStatus(
                 AnalyticsModule.HEATMAP,
                 false,
+                heatmapProgress,
                 LockedReason.MoreQuizzes(config.heatmapQuestions - stats.answered)
             )
         }
 
-        res += ModuleStatus(AnalyticsModule.PEER, stats.userSignedIn, null)
+        val peerProgress = if (stats.userSignedIn) 1f else 0f
+        res += ModuleStatus(AnalyticsModule.PEER, stats.userSignedIn, peerProgress, null)
 
         val requiredMs = config.timeGateHours * 60L * 60L * 1000L
         val elapsed = nowMillis - stats.lastQuizMillis
+        val timeProgress = min(elapsed / requiredMs.toFloat(), 1f)
         if (elapsed >= requiredMs) {
-            res += ModuleStatus(AnalyticsModule.TIME, true)
+            res += ModuleStatus(AnalyticsModule.TIME, true, timeProgress)
         } else {
             res += ModuleStatus(
                 AnalyticsModule.TIME,
                 false,
+                timeProgress,
                 LockedReason.TimeGate((requiredMs - elapsed).milliseconds)
             )
         }

--- a/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlockerTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/unlock/AnalyticsUnlockerTest.kt
@@ -1,5 +1,6 @@
 package com.concepts_and_quizzes.cds.data.analytics.unlock
 
+import com.concepts_and_quizzes.cds.core.config.RemoteConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.hours
@@ -17,16 +18,30 @@ class AnalyticsUnlockerTest {
         )
         val now = 2.hours.inWholeMilliseconds
         val statuses = unlocker.statuses(stats, now)
-        assertEquals(
-            ModuleStatus(AnalyticsModule.TREND, false, LockedReason.MoreQuizzes(1)),
-            statuses[0]
-        )
-        assertEquals(
-            ModuleStatus(AnalyticsModule.HEATMAP, false, LockedReason.MoreQuizzes(10)),
-            statuses[1]
-        )
-        assertEquals(ModuleStatus(AnalyticsModule.PEER, false, null), statuses[2])
-        val timeGate = statuses[3].reason as LockedReason.TimeGate
+
+        val trend = statuses[0]
+        assertEquals(AnalyticsModule.TREND, trend.module)
+        assertEquals(false, trend.unlocked)
+        assertEquals(2f / 3f, trend.progress, 0.001f)
+        assertEquals(LockedReason.MoreQuizzes(1), trend.reason)
+
+        val heatmap = statuses[1]
+        assertEquals(AnalyticsModule.HEATMAP, heatmap.module)
+        assertEquals(false, heatmap.unlocked)
+        assertEquals(0.8f, heatmap.progress, 0.001f)
+        assertEquals(LockedReason.MoreQuizzes(10), heatmap.reason)
+
+        val peer = statuses[2]
+        assertEquals(AnalyticsModule.PEER, peer.module)
+        assertEquals(false, peer.unlocked)
+        assertEquals(0f, peer.progress, 0.001f)
+        assertEquals(null, peer.reason)
+
+        val time = statuses[3]
+        assertEquals(AnalyticsModule.TIME, time.module)
+        assertEquals(false, time.unlocked)
+        assertEquals(2f / 24f, time.progress, 0.001f)
+        val timeGate = time.reason as LockedReason.TimeGate
         assertEquals(22.hours, timeGate.duration)
     }
 
@@ -40,6 +55,37 @@ class AnalyticsUnlockerTest {
         )
         val now = 25.hours.inWholeMilliseconds
         val statuses = unlocker.statuses(stats, now)
-        statuses.forEach { assertEquals(true, it.unlocked) }
+        statuses.forEach {
+            assertEquals(true, it.unlocked)
+            assertEquals(1f, it.progress, 0.001f)
+        }
+    }
+
+    @Test
+    fun `remote config override changes thresholds`() {
+        val rc = object : RemoteConfig {
+            override fun getBoolean(key: String) = true
+            override fun getString(key: String): String? =
+                """{"trendQuizzes":5,"heatmapQuestions":40,"timeGateHours":12}"""
+        }
+        val unlocker = AnalyticsUnlocker(AnalyticsUnlockConfig(rc))
+        val stats = UnlockStats(
+            sessionsLast7d = 4,
+            answered = 50,
+            userSignedIn = true,
+            lastQuizMillis = 0L
+        )
+        val now = 12.hours.inWholeMilliseconds
+        val statuses = unlocker.statuses(stats, now)
+
+        val trend = statuses.first { it.module == AnalyticsModule.TREND }
+        assertEquals(false, trend.unlocked)
+        assertEquals(4f / 5f, trend.progress, 0.001f)
+
+        val heatmap = statuses.first { it.module == AnalyticsModule.HEATMAP }
+        assertEquals(true, heatmap.unlocked)
+
+        val time = statuses.first { it.module == AnalyticsModule.TIME }
+        assertEquals(true, time.unlocked)
     }
 }


### PR DESCRIPTION
## Summary
- track per-module unlock progress
- allow remote config JSON override of unlock thresholds
- test AnalyticsUnlocker with progress and RC overrides

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895666a78d483299a67e78e23ecffb4