### PR TITLE
feat(ui): add skeleton charts for ghost previews

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/HeatmapSkeleton.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/HeatmapSkeleton.kt
@@ -1,0 +1,39 @@
+package com.concepts_and_quizzes.cds.ui.skeleton
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+
+/**
+ * Skeleton placeholder for heat map charts.
+ */
+@Composable
+fun HeatmapSkeleton(modifier: Modifier = Modifier) {
+    Canvas(
+        modifier
+            .fillMaxWidth()
+            .height(120.dp)
+    ) {
+        val rows = 5
+        val columns = 7
+        val cellWidth = size.width / columns
+        val cellHeight = size.height / rows
+        for (r in 0 until rows) {
+            for (c in 0 until columns) {
+                drawRect(
+                    color = SkeletonDefaults.strokeColor,
+                    topLeft = Offset(c * cellWidth, r * cellHeight),
+                    size = Size(cellWidth, cellHeight),
+                    style = Stroke(width = 2.dp.toPx())
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/PeerSkeleton.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/PeerSkeleton.kt
@@ -1,0 +1,41 @@
+package com.concepts_and_quizzes.cds.ui.skeleton
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+
+/**
+ * Skeleton placeholder for peer comparison charts.
+ */
+@Composable
+fun PeerSkeleton(modifier: Modifier = Modifier) {
+    Canvas(
+        modifier
+            .size(120.dp)
+    ) {
+        val strokeWidth = 4.dp.toPx()
+        val arcSize = Size(size.width - strokeWidth, size.height - strokeWidth)
+        val topLeft = Offset(strokeWidth / 2, strokeWidth / 2)
+        drawArc(
+            color = SkeletonDefaults.strokeColor,
+            startAngle = 0f,
+            sweepAngle = 360f,
+            useCenter = false,
+            style = Stroke(width = strokeWidth),
+            topLeft = topLeft,
+            size = arcSize
+        )
+        drawLine(
+            color = SkeletonDefaults.strokeColor,
+            start = center,
+            end = Offset(size.width, center.y),
+            strokeWidth = strokeWidth
+        )
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/SkeletonDefaults.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/SkeletonDefaults.kt
@@ -1,0 +1,11 @@
+package com.concepts_and_quizzes.cds.ui.skeleton
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Shared style values for skeleton charts.
+ */
+internal object SkeletonDefaults {
+    val strokeColor: Color = Color(0xFFBDBDBD).copy(alpha = 0.3f)
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/TimeSkeleton.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/TimeSkeleton.kt
@@ -1,0 +1,37 @@
+package com.concepts_and_quizzes.cds.ui.skeleton
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.drawscope.StrokeCap
+import androidx.compose.ui.unit.dp
+
+/**
+ * Skeleton placeholder for time distribution charts.
+ */
+@Composable
+fun TimeSkeleton(modifier: Modifier = Modifier) {
+    Canvas(
+        modifier
+            .fillMaxWidth()
+            .height(120.dp)
+    ) {
+        val bars = 7
+        val barSpacing = size.width / (bars * 2f)
+        for (i in 0 until bars) {
+            val x = barSpacing * (i * 2 + 1)
+            val barHeight = size.height * (0.3f + (i % 3) * 0.2f)
+            drawLine(
+                color = SkeletonDefaults.strokeColor,
+                start = Offset(x, size.height),
+                end = Offset(x, size.height - barHeight),
+                strokeWidth = barSpacing,
+                cap = StrokeCap.Round
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/TrendSkeleton.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/skeleton/TrendSkeleton.kt
@@ -1,0 +1,37 @@
+package com.concepts_and_quizzes.cds.ui.skeleton
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+
+/**
+ * Skeleton placeholder for trend line charts.
+ */
+@Composable
+fun TrendSkeleton(modifier: Modifier = Modifier) {
+    Canvas(
+        modifier
+            .fillMaxWidth()
+            .height(120.dp)
+    ) {
+        val path = Path().apply {
+            moveTo(0f, size.height * 0.8f)
+            lineTo(size.width * 0.2f, size.height * 0.6f)
+            lineTo(size.width * 0.4f, size.height * 0.7f)
+            lineTo(size.width * 0.6f, size.height * 0.4f)
+            lineTo(size.width * 0.8f, size.height * 0.5f)
+            lineTo(size.width, size.height * 0.3f)
+        }
+        drawPath(
+            path = path,
+            color = SkeletonDefaults.strokeColor,
+            style = Stroke(width = 4.dp.toPx())
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- add canvas-based placeholder components for trend, heatmap, time distribution, and peer charts
- centralize skeleton stroke color

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689568dc835c8329a208bc40ff31de0a