### PR TITLE
feat(ui): ghost teaser preview for locked analytics modules

### DIFF
--- a/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/GhostOverlayVisibilityTest.kt
+++ b/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/GhostOverlayVisibilityTest.kt
@@ -1,0 +1,38 @@
+package com.concepts_and_quizzes.cds.ui.reports
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import org.junit.Rule
+import org.junit.Test
+import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
+
+class GhostOverlayVisibilityTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun overlayHidesWhenUnlocked() {
+        val unlocked = mutableStateOf(false)
+        composeTestRule.setContent {
+            GhostOverlay(
+                unlocked = unlocked.value,
+                reason = LockedReason.MoreQuizzes(1),
+                skeleton = {},
+            ) {
+                // empty content
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Locked").assertIsDisplayed()
+
+        composeTestRule.runOnUiThread { unlocked.value = true }
+        composeTestRule.waitUntil(timeoutMillis = 1000) {
+            composeTestRule.onAllNodesWithContentDescription("Locked").fetchSemanticsNodes().isEmpty()
+        }
+        composeTestRule.onAllNodesWithContentDescription("Locked").assertCountEquals(0)
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/GhostOverlay.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/GhostOverlay.kt
@@ -1,0 +1,68 @@
+package com.concepts_and_quizzes.cds.ui.reports
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
+import com.concepts_and_quizzes.cds.util.toPretty
+
+/**
+ * Wraps [content] with a ghost overlay displayed when the analytics module is locked.
+ * Shows a skeleton preview, lock icon and call to action which fades away once unlocked.
+ */
+@Composable
+fun GhostOverlay(
+    unlocked: Boolean,
+    reason: LockedReason?,
+    modifier: Modifier = Modifier,
+    skeleton: @Composable BoxScope.() -> Unit,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Box(modifier) {
+        Box(Modifier.fillMaxSize(), content = content)
+        AnimatedContent(
+            targetState = unlocked,
+            transitionSpec = { fadeIn() togetherWith fadeOut() },
+            label = "ghostOverlay"
+        ) { isUnlocked ->
+            if (!isUnlocked) {
+                Box(Modifier.fillMaxSize()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .alpha(0.3f),
+                        contentAlignment = Alignment.Center,
+                        content = skeleton
+                    )
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Icon(Icons.Filled.Lock, contentDescription = "Locked")
+                        reason?.let {
+                            val msg = when (it) {
+                                is LockedReason.MoreQuizzes -> "Complete ${it.remaining} more quizzes"
+                                is LockedReason.TimeGate -> "Unlock in ${it.duration.toPretty()}"
+                            }
+                            Text(msg, style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
@@ -8,6 +8,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
+import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
+import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
+import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
+import com.concepts_and_quizzes.cds.ui.skeleton.HeatmapSkeleton
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -15,9 +20,22 @@ import javax.inject.Inject
 class HeatMapViewModel @Inject constructor() : ViewModel()
 
 @Composable
-fun HeatMapPage(vm: HeatMapViewModel = hiltViewModel()) {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Heat Map")
+fun HeatMapPage(
+    status: ModuleStatus = ModuleStatus(
+        module = AnalyticsModule.HEATMAP,
+        unlocked = false,
+        progress = 0f,
+        reason = LockedReason.MoreQuizzes(5)
+    ),
+    vm: HeatMapViewModel = hiltViewModel()
+) {
+    GhostOverlay(
+        unlocked = status.unlocked,
+        reason = status.reason,
+        skeleton = { HeatmapSkeleton() },
+    ) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Heat Map")
+        }
     }
 }
-

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
@@ -8,6 +8,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
+import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
+import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
+import com.concepts_and_quizzes.cds.ui.skeleton.PeerSkeleton
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -15,9 +19,22 @@ import javax.inject.Inject
 class PeerViewModel @Inject constructor() : ViewModel()
 
 @Composable
-fun PeerPage(vm: PeerViewModel = hiltViewModel()) {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Peer")
+fun PeerPage(
+    status: ModuleStatus = ModuleStatus(
+        module = AnalyticsModule.PEER,
+        unlocked = false,
+        progress = 0f,
+        reason = null
+    ),
+    vm: PeerViewModel = hiltViewModel()
+) {
+    GhostOverlay(
+        unlocked = status.unlocked,
+        reason = status.reason,
+        skeleton = { PeerSkeleton() },
+    ) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Peer")
+        }
     }
 }
-

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
@@ -8,16 +8,35 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
+import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
+import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
+import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
+import com.concepts_and_quizzes.cds.ui.skeleton.TimeSkeleton
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.hours
 
 @HiltViewModel
 class TimeViewModel @Inject constructor() : ViewModel()
 
 @Composable
-fun TimePage(vm: TimeViewModel = hiltViewModel()) {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Time")
+fun TimePage(
+    status: ModuleStatus = ModuleStatus(
+        module = AnalyticsModule.TIME,
+        unlocked = false,
+        progress = 0f,
+        reason = LockedReason.TimeGate(5.hours)
+    ),
+    vm: TimeViewModel = hiltViewModel()
+) {
+    GhostOverlay(
+        unlocked = status.unlocked,
+        reason = status.reason,
+        skeleton = { TimeSkeleton() },
+    ) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Time")
+        }
     }
 }
-

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
@@ -8,6 +8,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
+import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
+import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
+import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
+import com.concepts_and_quizzes.cds.ui.skeleton.TrendSkeleton
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -15,9 +20,22 @@ import javax.inject.Inject
 class TrendViewModel @Inject constructor() : ViewModel()
 
 @Composable
-fun TrendPage(vm: TrendViewModel = hiltViewModel()) {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Trend")
+fun TrendPage(
+    status: ModuleStatus = ModuleStatus(
+        module = AnalyticsModule.TREND,
+        unlocked = false,
+        progress = 0f,
+        reason = LockedReason.MoreQuizzes(3)
+    ),
+    vm: TrendViewModel = hiltViewModel()
+) {
+    GhostOverlay(
+        unlocked = status.unlocked,
+        reason = status.reason,
+        skeleton = { TrendSkeleton() },
+    ) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Trend")
+        }
     }
 }
-


### PR DESCRIPTION
## Summary
- add GhostOverlay wrapper to show skeleton lock overlay with CTA
- integrate overlay across analytics pages for trend, heatmap, time, and peer modules
- test overlay visibility behaviour in Compose UI

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956c454f04832998e71c744842bd33