### PR TITLE
feat(telemetry): events for ghost analytics funnel

### DIFF
--- a/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/GhostOverlayVisibilityTest.kt
+++ b/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/GhostOverlayVisibilityTest.kt
@@ -8,7 +8,9 @@ import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import org.junit.Rule
 import org.junit.Test
+import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
 import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
+import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
 
 class GhostOverlayVisibilityTest {
     @get:Rule
@@ -16,11 +18,17 @@ class GhostOverlayVisibilityTest {
 
     @Test
     fun overlayHidesWhenUnlocked() {
-        val unlocked = mutableStateOf(false)
+        val status = mutableStateOf(
+            ModuleStatus(
+                module = AnalyticsModule.TREND,
+                unlocked = false,
+                progress = 0f,
+                reason = LockedReason.MoreQuizzes(1)
+            )
+        )
         composeTestRule.setContent {
             GhostOverlay(
-                unlocked = unlocked.value,
-                reason = LockedReason.MoreQuizzes(1),
+                status = status.value,
                 skeleton = {},
             ) {
                 // empty content
@@ -29,7 +37,7 @@ class GhostOverlayVisibilityTest {
 
         composeTestRule.onNodeWithContentDescription("Locked").assertIsDisplayed()
 
-        composeTestRule.runOnUiThread { unlocked.value = true }
+        composeTestRule.runOnUiThread { status.value = status.value.copy(unlocked = true, reason = null) }
         composeTestRule.waitUntil(timeoutMillis = 1000) {
             composeTestRule.onAllNodesWithContentDescription("Locked").fetchSemanticsNodes().isEmpty()
         }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/telemetry/Telemetry.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/telemetry/Telemetry.kt
@@ -1,0 +1,41 @@
+package com.concepts_and_quizzes.cds.data.analytics.telemetry
+
+import android.util.Log
+
+private const val TAG = "Telemetry"
+
+/**
+ * Simple analytics helper used for logging funnel events.
+ * Currently logs to [Log] but can be wired to Firebase in the future.
+ */
+object Telemetry {
+
+    private interface Logger {
+        fun log(event: String, params: Map<String, Any>)
+    }
+
+    private object FirebaseStubLogger : Logger {
+        override fun log(event: String, params: Map<String, Any>) {
+            Log.d(TAG, "$event: $params")
+            // TODO: integrate Firebase Analytics once available
+        }
+    }
+
+    private val logger: Logger = FirebaseStubLogger
+
+    fun logUnlockView(module: String, remaining: Int, progress: Float) {
+        logger.log(
+            "unlock_view",
+            mapOf(
+                "module" to module,
+                "remaining" to remaining,
+                "progress" to progress
+            )
+        )
+    }
+
+    fun logUnlockSuccess(module: String) {
+        logger.log("unlock_success", mapOf("module" to module))
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/GhostOverlay.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/GhostOverlay.kt
@@ -14,10 +14,17 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
+import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
+import com.concepts_and_quizzes.cds.data.analytics.telemetry.Telemetry
 import com.concepts_and_quizzes.cds.util.toPretty
 
 /**
@@ -26,18 +33,33 @@ import com.concepts_and_quizzes.cds.util.toPretty
  */
 @Composable
 fun GhostOverlay(
-    unlocked: Boolean,
-    reason: LockedReason?,
+    status: ModuleStatus,
     modifier: Modifier = Modifier,
     skeleton: @Composable BoxScope.() -> Unit,
     content: @Composable BoxScope.() -> Unit,
 ) {
+    val unlocked = status.unlocked
+    val reason = status.reason
+
+    var loggedView by remember { mutableStateOf(false) }
+    LaunchedEffect(unlocked) {
+        val moduleName = status.module.name
+        val remaining = (reason as? LockedReason.MoreQuizzes)?.remaining ?: 0
+        if (!unlocked && !loggedView) {
+            Telemetry.logUnlockView(moduleName, remaining, status.progress)
+            loggedView = true
+        } else if (unlocked && loggedView) {
+            Telemetry.logUnlockSuccess(moduleName)
+            loggedView = false
+        }
+    }
+
     Box(modifier) {
         Box(Modifier.fillMaxSize(), content = content)
         AnimatedContent(
             targetState = unlocked,
             transitionSpec = { fadeIn() togetherWith fadeOut() },
-            label = "ghostOverlay"
+            label = "ghostOverlay",
         ) { isUnlocked ->
             if (!isUnlocked) {
                 Box(Modifier.fillMaxSize()) {
@@ -46,11 +68,11 @@ fun GhostOverlay(
                             .fillMaxSize()
                             .alpha(0.3f),
                         contentAlignment = Alignment.Center,
-                        content = skeleton
+                        content = skeleton,
                     )
                     Column(
                         modifier = Modifier.align(Alignment.Center),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         Icon(Icons.Filled.Lock, contentDescription = "Locked")
                         reason?.let {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
@@ -30,8 +30,7 @@ fun HeatMapPage(
     vm: HeatMapViewModel = hiltViewModel()
 ) {
     GhostOverlay(
-        unlocked = status.unlocked,
-        reason = status.reason,
+        status = status,
         skeleton = { HeatmapSkeleton() },
     ) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
@@ -29,8 +29,7 @@ fun PeerPage(
     vm: PeerViewModel = hiltViewModel()
 ) {
     GhostOverlay(
-        unlocked = status.unlocked,
-        reason = status.reason,
+        status = status,
         skeleton = { PeerSkeleton() },
     ) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
@@ -31,8 +31,7 @@ fun TimePage(
     vm: TimeViewModel = hiltViewModel()
 ) {
     GhostOverlay(
-        unlocked = status.unlocked,
-        reason = status.reason,
+        status = status,
         skeleton = { TimeSkeleton() },
     ) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
@@ -30,8 +30,7 @@ fun TrendPage(
     vm: TrendViewModel = hiltViewModel()
 ) {
     GhostOverlay(
-        unlocked = status.unlocked,
-        reason = status.reason,
+        status = status,
         skeleton = { TrendSkeleton() },
     ) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {


### PR DESCRIPTION
## Summary
- add telemetry helper to log unlock funnel events
- trigger unlock_view and unlock_success from GhostOverlay
- update pages and tests for new GhostOverlay API

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956fe0e8bc832999815c73e9219f38