### PR TITLE
Limit discover carousel text to two lines

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/DiscoverComponents.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/DiscoverComponents.kt
@@ -57,12 +57,17 @@ fun DiscoverCard(
                 Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.Top
             ) {
+                val titleHeight = with(LocalDensity.current) {
+                    MaterialTheme.typography.titleMedium.lineHeight.toDp() * 2
+                }
                 Text(
                     concept.title,
                     style = MaterialTheme.typography.titleMedium,
-                    maxLines = 1,
+                    maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(titleHeight)
                 )
                 IconToggleButton(
                     checked = bookmarked,
@@ -88,12 +93,12 @@ fun DiscoverCard(
             }
             Spacer(Modifier.height(8.dp))
             val textHeight = with(LocalDensity.current) {
-                MaterialTheme.typography.bodyMedium.lineHeight.toDp() * 3
+                MaterialTheme.typography.bodyMedium.lineHeight.toDp() * 2
             }
             Text(
                 concept.blurb,
                 style = MaterialTheme.typography.bodyMedium,
-                maxLines = 3,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.height(textHeight)
             )


### PR DESCRIPTION
## Summary
- Allow discover carousel card titles to span two lines with ellipsis
- Restrict card descriptions to two lines and keep height consistent

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68957632b26883299c085ad32eedb248