### PR TITLE
Improve quiz accessibility and add analysis CTAs

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/PaletteBottomSheet.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/PaletteBottomSheet.kt
@@ -1,0 +1,73 @@
+package com.concepts_and_quizzes.cds.ui.quiz
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Flag
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.ExperimentalMaterial3Api
+import com.concepts_and_quizzes.cds.core.theme.flaggedContainer
+import com.concepts_and_quizzes.cds.core.theme.flaggedOnContainer
+import com.concepts_and_quizzes.cds.ui.english.pyqp.QuizViewModel
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun PaletteBottomSheet(
+    entries: List<QuizViewModel.PaletteEntry>,
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Jump to question", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(8.dp))
+            QuestionLegend()
+            Spacer(Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Outlined.Flag, contentDescription = null, tint = MaterialTheme.colorScheme.flaggedOnContainer)
+                Spacer(Modifier.width(4.dp))
+                Text("Flagged question")
+            }
+            Spacer(Modifier.height(8.dp))
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(5),
+                modifier = Modifier.heightIn(max = 200.dp)
+            ) {
+                items(entries.size) { idx ->
+                    val e = entries[idx]
+                    val container = when {
+                        e.flagged -> MaterialTheme.colorScheme.flaggedContainer
+                        e.answered -> MaterialTheme.colorScheme.primaryContainer
+                        else -> MaterialTheme.colorScheme.surfaceVariant
+                    }
+                    val content = when {
+                        e.flagged -> MaterialTheme.colorScheme.flaggedOnContainer
+                        e.answered -> MaterialTheme.colorScheme.onPrimaryContainer
+                        else -> MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                    Box(
+                        modifier = Modifier
+                            .padding(4.dp)
+                            .size(48.dp)
+                            .background(container, RoundedCornerShape(8.dp))
+                            .clickable { onSelect(e.questionIndex) },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("${e.questionIndex + 1}", color = content)
+                    }
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreenNavigationTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreenNavigationTest.kt
@@ -1,0 +1,51 @@
+package com.concepts_and_quizzes.cds.ui.english.analysis
+
+import android.content.Context
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.test.core.app.ApplicationProvider
+import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReport
+import com.concepts_and_quizzes.cds.data.analytics.repo.TopicSummary
+import com.concepts_and_quizzes.cds.data.settings.UserPreferences
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AnalysisScreenNavigationTest {
+    @get:Rule val composeRule = createComposeRule()
+
+    @Test
+    fun retakeWeakestNavigatesToTopicPractice() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = UserPreferences(context)
+        val report = QuizReport(
+            total = 10,
+            attempted = 10,
+            correct = 5,
+            wrong = 5,
+            strongestTopic = null,
+            weakestTopic = null,
+            timePerSection = listOf(
+                TopicSummary(topicId = 1, accuracy = 50.0, avgTime = 0.0, attempts = 6)
+            ),
+            bottlenecks = emptyList(),
+            suggestions = emptyList()
+        )
+        val nav = object : NavHostController(context) {
+            var route: String? = null
+            override fun navigate(route: String, navOptions: NavOptions?, navigatorExtras: Navigator.Extras?) {
+                this.route = route
+            }
+        }
+        composeRule.setContent { AnalysisScreen(report, prefs, nav) }
+        composeRule.onNodeWithText("Retake weakest topic").performClick()
+        assertTrue(nav.route!!.startsWith("english/pyqp?mode=TOPIC"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add accessibility semantics and progress pulse transition in `QuizScreen`
- Introduce `PaletteBottomSheet` with legend and flag explanation
- Compute weakest topics and surface CTAs in `AnalysisScreen`
- Add navigation test for weakest topic CTA

## Testing
- `./gradlew :app:assembleDebug :app:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689589a5744c8329890fd5b7f06e999b