### PR TITLE
feat: share reports and unify states

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/components/States.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/components/States.kt
@@ -1,0 +1,63 @@
+package com.concepts_and_quizzes.cds.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+sealed class UiState<out T> {
+    object Loading : UiState<Nothing>()
+    data class Empty(val title: String, val actionLabel: String? = null) : UiState<Nothing>()
+    data class Error(val message: String) : UiState<Nothing>()
+    data class Data<T>(val value: T) : UiState<T>()
+}
+
+@Composable
+fun LoadingSkeleton() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+fun EmptyState(
+    title: String,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null
+) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(text = title)
+            if (actionLabel != null && onAction != null) {
+                Spacer(Modifier.height(16.dp))
+                Button(onClick = onAction) { Text(actionLabel) }
+            }
+        }
+    }
+}
+
+@Composable
+fun ErrorState(
+    message: String,
+    onRetry: (() -> Unit)?
+) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(text = message, color = MaterialTheme.colorScheme.error)
+            if (onRetry != null) {
+                Spacer(Modifier.height(16.dp))
+                Button(onClick = onRetry) { Text("Retry") }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpPaperListScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpPaperListScreen.kt
@@ -17,26 +17,31 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
 
 @Composable
 fun PyqpPaperListScreen(nav: NavController, vm: PyqpListViewModel = hiltViewModel()) {
     val papers by vm.papers.collectAsState()
     Scaffold { padd ->
-        LazyColumn(contentPadding = padd) {
-            items(papers) { paper ->
-                ListItem(
-                    headlineContent = { Text("CDS ${paper.year}  ${paper.id.takeLast(5)}") },
-                    trailingContent = {
-                        Icon(
-                            Icons.Filled.ChevronRight,
-                            contentDescription = "Open paper"
-                        )
-                    },
-                    modifier = Modifier.clickable {
-                        nav.navigate("english/pyqp/${paper.id}")
-                    }
-                )
-                HorizontalDivider(Modifier, DividerDefaults.Thickness, DividerDefaults.color)
+        if (papers.isEmpty()) {
+            EmptyState(title = "No papers")
+        } else {
+            LazyColumn(contentPadding = padd) {
+                items(papers) { paper ->
+                    ListItem(
+                        headlineContent = { Text("CDS ${paper.year}  ${paper.id.takeLast(5)}") },
+                        trailingContent = {
+                            Icon(
+                                Icons.Filled.ChevronRight,
+                                contentDescription = "Open paper"
+                            )
+                        },
+                        modifier = Modifier.clickable {
+                            nav.navigate("english/pyqp/${paper.id}")
+                        }
+                    )
+                    HorizontalDivider(Modifier, DividerDefaults.Thickness, DividerDefaults.color)
+                }
             }
         }
     }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizPage.kt
@@ -1,0 +1,23 @@
+package com.concepts_and_quizzes.cds.ui.reports
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
+import com.concepts_and_quizzes.cds.ui.english.analysis.AnalysisScreen
+
+@Composable
+fun LastQuizPage(sessionId: String?) {
+    val vm: LastQuizViewModel = hiltViewModel()
+    LaunchedEffect(sessionId) { vm.load(sessionId) }
+    val report by vm.report.collectAsState()
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        report?.let { AnalysisScreen(it, vm.prefs) } ?: EmptyState(title = "No reports")
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
@@ -1,35 +1,50 @@
 package com.concepts_and_quizzes.cds.ui.reports
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Rect
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.core.content.FileProvider
+import androidx.core.view.drawToBitmap
 import kotlinx.coroutines.launch
 import com.concepts_and_quizzes.cds.ui.reports.trend.TrendPage
 import com.concepts_and_quizzes.cds.ui.reports.heatmap.HeatMapPage
 import com.concepts_and_quizzes.cds.ui.reports.time.TimePage
 import com.concepts_and_quizzes.cds.ui.reports.peer.PeerPage
-import com.concepts_and_quizzes.cds.ui.english.analysis.AnalysisScreen
+import java.io.File
+import java.io.FileOutputStream
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -40,43 +55,86 @@ fun ReportsScreen(
     val window by shared.window.collectAsState()
     val pagerState = rememberPagerState(initialPage = shared.startPage, pageCount = { 5 })
     val scope = rememberCoroutineScope()
-    Column {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Window.entries.forEach { w ->
-                FilterChip(
-                    selected = window == w,
-                    onClick = { shared.setWindow(w) },
-                    label = { Text(text = w.label) }
-                )
-            }
+    val context = LocalContext.current
+    val view = LocalView.current
+    var pagerRect by remember { mutableStateOf<Rect?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Reports") },
+                actions = {
+                    IconButton(onClick = {
+                        pagerRect?.let { rect ->
+                            val bitmap = view.drawToBitmap()
+                            val crop = Bitmap.createBitmap(bitmap, rect.left, rect.top, rect.width(), rect.height())
+                            val dir = File(context.cacheDir, "reports")
+                            dir.mkdirs()
+                            val file = File(dir, "report.png")
+                            FileOutputStream(file).use { out ->
+                                crop.compress(Bitmap.CompressFormat.PNG, 100, out)
+                            }
+                            val uri = FileProvider.getUriForFile(
+                                context,
+                                "${context.packageName}.provider",
+                                file
+                            )
+                            val intent = Intent(Intent.ACTION_SEND).apply {
+                                type = "image/png"
+                                putExtra(Intent.EXTRA_STREAM, uri)
+                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                            }
+                            context.startActivity(Intent.createChooser(intent, null))
+                        }
+                    }) {
+                        Icon(Icons.Filled.Share, contentDescription = "Share")
+                    }
+                }
+            )
         }
-        val tabs = listOf("Last", "Trend", "Heatmap", "Time", "Peer")
-        TabRow(selectedTabIndex = pagerState.currentPage) {
-            tabs.forEachIndexed { index, title ->
-                Tab(
-                    selected = pagerState.currentPage == index,
-                    onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
-                    text = { Text(title) }
-                )
+    ) { inner ->
+        Column(modifier = Modifier.padding(inner)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Window.entries.forEach { w ->
+                    FilterChip(
+                        selected = window == w,
+                        onClick = { shared.setWindow(w) },
+                        label = { Text(text = w.label) }
+                    )
+                }
             }
-        }
-        VerticalPager(
-            state = pagerState,
-            modifier = Modifier
-                .weight(1f)
-                .testTag("reportsPager")
-        ) { page ->
-            when (page) {
-                0 -> LastQuizPage(navArgs.analysisSessionId)
-                1 -> TrendPage()
-                2 -> HeatMapPage()
-                3 -> TimePage()
-                4 -> PeerPage()
+            val tabs = listOf("Last", "Trend", "Heatmap", "Time", "Peer")
+            TabRow(selectedTabIndex = pagerState.currentPage) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = pagerState.currentPage == index,
+                        onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
+                        text = { Text(title) }
+                    )
+                }
+            }
+            VerticalPager(
+                state = pagerState,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("reportsPager")
+                    .onGloballyPositioned { coords ->
+                        val b = coords.boundsInWindow()
+                        pagerRect = Rect(b.left.toInt(), b.top.toInt(), b.right.toInt(), b.bottom.toInt())
+                    }
+            ) { page ->
+                when (page) {
+                    0 -> LastQuizPage(navArgs.analysisSessionId)
+                    1 -> TrendPage()
+                    2 -> HeatMapPage()
+                    3 -> TimePage()
+                    4 -> PeerPage()
+                }
             }
         }
     }
@@ -88,14 +146,4 @@ fun ReportsPagerScreen(
     startPage: Int = 0
 ) {
     ReportsScreen(navArgs = navArgs)
-}
-
-@Composable
-fun LastQuizPage(sessionId: String?) {
-    val vm: LastQuizViewModel = hiltViewModel()
-    LaunchedEffect(sessionId) { vm.load(sessionId) }
-    val report by vm.report.collectAsState()
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        report?.let { AnalysisScreen(it, vm.prefs) } ?: Text("No reports")
-    }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
@@ -2,7 +2,6 @@ package com.concepts_and_quizzes.cds.ui.reports.heatmap
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -13,6 +12,7 @@ import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
 import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
 import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
 import com.concepts_and_quizzes.cds.ui.skeleton.HeatmapSkeleton
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -34,7 +34,7 @@ fun HeatMapPage(
         skeleton = { HeatmapSkeleton() },
     ) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("Heat Map")
+            EmptyState(title = "No heat map data")
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
@@ -2,7 +2,6 @@ package com.concepts_and_quizzes.cds.ui.reports.peer
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -12,6 +11,7 @@ import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
 import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
 import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
 import com.concepts_and_quizzes.cds.ui.skeleton.PeerSkeleton
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -33,7 +33,7 @@ fun PeerPage(
         skeleton = { PeerSkeleton() },
     ) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("Peer")
+            EmptyState(title = "No peer data")
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
@@ -2,7 +2,6 @@ package com.concepts_and_quizzes.cds.ui.reports.time
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -13,6 +12,7 @@ import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
 import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
 import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
 import com.concepts_and_quizzes.cds.ui.skeleton.TimeSkeleton
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.hours
@@ -35,7 +35,7 @@ fun TimePage(
         skeleton = { TimeSkeleton() },
     ) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("Time")
+            EmptyState(title = "No time data")
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
@@ -2,7 +2,6 @@ package com.concepts_and_quizzes.cds.ui.reports.trend
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -13,6 +12,7 @@ import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
 import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
 import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
 import com.concepts_and_quizzes.cds.ui.skeleton.TrendSkeleton
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -34,7 +34,7 @@ fun TrendPage(
         skeleton = { TrendSkeleton() },
     ) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("Trend")
+            EmptyState(title = "No trend data")
         }
     }
 }


### PR DESCRIPTION
## Summary
- add unified `UiState` helpers for loading, empty and error placeholders
- show empty placeholders for reports and paper list using shared states
- enable sharing current report page via top bar action

## Testing
- `./gradlew :app:assembleDebug :app:testDebugUnitTest` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68958d6c75a48329be2014b2ca48f1bc