### PR TITLE
Optimize dashboard and reports with navigation tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+### Summary
+What changed and why
+
+### Screenshots
+Before and after
+
+### Checks
+- [ ] Built locally
+- [ ] Unit or UI tests updated or added
+- [ ] Accessibility reviewed
+- [ ] No new dependencies
+

--- a/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/main/BottomBarUiTest.kt
+++ b/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/main/BottomBarUiTest.kt
@@ -1,0 +1,65 @@
+package com.concepts_and_quizzes.cds.ui.main
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.concepts_and_quizzes.cds.core.components.CdsBottomNavBar
+import com.concepts_and_quizzes.cds.core.config.RemoteConfig
+import com.concepts_and_quizzes.cds.ui.nav.isAnalytics
+import com.concepts_and_quizzes.cds.ui.nav.isConcepts
+import com.concepts_and_quizzes.cds.ui.nav.isPyqp
+import com.concepts_and_quizzes.cds.ui.nav.isReports
+import org.junit.Rule
+import org.junit.Test
+
+class BottomBarUiTest {
+    @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Composable
+    private fun TestScaffold(route: String) {
+        val navController = rememberNavController()
+        NavHost(navController, startDestination = "english/dashboard") {
+            composable("english/dashboard") {}
+            composable("english/pyqp/{paperId}") {}
+            composable("analysis/{sessionId}") {}
+            composable("reports") {}
+        }
+        LaunchedEffect(route) { navController.navigate(route) }
+        val navBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentRoute = navBackStackEntry?.destination?.route
+        val rc = object : RemoteConfig { override fun getBoolean(key: String) = true }
+        val showBottomBar = currentRoute == "english/dashboard" ||
+            isConcepts(currentRoute) ||
+            currentRoute == "quizHub" ||
+            isPyqp(currentRoute) ||
+            isAnalytics(currentRoute) ||
+            isReports(currentRoute)
+
+        Scaffold(bottomBar = { if (showBottomBar) CdsBottomNavBar(navController, rc) }) {}
+    }
+
+    @Test
+    fun bottomBarVisibleOnParameterizedPyqp() {
+        composeRule.setContent { TestScaffold("english/pyqp/1") }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Dashboard").assertExists()
+    }
+
+    @Test
+    fun bottomBarHiddenOnAnalysisRoute() {
+        composeRule.setContent { TestScaffold("analysis/123") }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Dashboard").assertDoesNotExist()
+    }
+}
+

--- a/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/ReportsTabsUiTest.kt
+++ b/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/reports/ReportsTabsUiTest.kt
@@ -1,0 +1,26 @@
+package com.concepts_and_quizzes.cds.ui.reports
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+
+class ReportsTabsUiTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun tabClickChangesPage() {
+        composeRule.setContent { ReportsPagerScreen() }
+
+        composeRule.onNodeWithText("No reports").assertIsDisplayed()
+
+        composeRule.onNodeWithText("Trend").performClick()
+
+        composeRule.onNodeWithText("No trend data").assertIsDisplayed()
+    }
+}
+

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -55,11 +56,13 @@ fun AnalysisScreen(
         play = true
     }
 
-    val weakest = remember(report) {
-        val perfs = report.timePerSection.map {
-            TopicPerf(it.topicId.toString(), it.attempts, (it.accuracy * it.attempts / 100).toInt())
+    val weakest by remember(report) {
+        derivedStateOf {
+            val perfs = report.timePerSection.map {
+                TopicPerf(it.topicId.toString(), it.attempts, (it.accuracy * it.attempts / 100).toInt())
+            }
+            weakestTopic(perfs)
         }
-        weakestTopic(perfs)
     }
 
     Box {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubViewModel.kt
@@ -4,7 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import com.concepts_and_quizzes.cds.data.quiz.QuizResumeStore
 
@@ -13,6 +16,23 @@ class QuizHubViewModel @Inject constructor(
     private val resumeStore: QuizResumeStore
 ) : ViewModel() {
     val store: StateFlow<QuizResumeStore.Store?> = resumeStore.store
+
+    data class SavedProgress(
+        val paperId: String,
+        val questionIndex: Int,
+        val percent: Int
+    )
+
+    private fun parseProgress(store: QuizResumeStore.Store): SavedProgress {
+        val parts = store.snapshot.split("|")
+        val answered = parts.getOrNull(1)?.takeIf { it.isNotBlank() }?.split(";")?.size ?: 0
+        val percent = answered * 100 / 60
+        return SavedProgress(store.paperId, answered, percent)
+    }
+
+    val progress: StateFlow<SavedProgress?> =
+        resumeStore.store.map { it?.let(::parseProgress) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     fun restore(snapshot: String) {
         viewModelScope.launch { resumeStore.restore(snapshot) }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -58,6 +59,9 @@ fun ReportsScreen(
     val context = LocalContext.current
     val view = LocalView.current
     var pagerRect by remember { mutableStateOf<Rect?>(null) }
+    val currentPage by remember { derivedStateOf { pagerState.currentPage } }
+    val tabs = remember { listOf("Last", "Trend", "Heatmap", "Time", "Peer") }
+    val windows = remember { Window.entries }
 
     Scaffold(
         topBar = {
@@ -100,7 +104,7 @@ fun ReportsScreen(
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Window.entries.forEach { w ->
+                windows.forEach { w ->
                     FilterChip(
                         selected = window == w,
                         onClick = { shared.setWindow(w) },
@@ -108,11 +112,10 @@ fun ReportsScreen(
                     )
                 }
             }
-            val tabs = listOf("Last", "Trend", "Heatmap", "Time", "Peer")
-            TabRow(selectedTabIndex = pagerState.currentPage) {
+            TabRow(selectedTabIndex = currentPage) {
                 tabs.forEachIndexed { index, title ->
                     Tab(
-                        selected = pagerState.currentPage == index,
+                        selected = currentPage == index,
                         onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
                         text = { Text(title) }
                     )

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/nav/RouteMatchersTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/nav/RouteMatchersTest.kt
@@ -1,0 +1,36 @@
+package com.concepts_and_quizzes.cds.ui.nav
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteMatchersTest {
+    @Test
+    fun reportsMatcher() {
+        assertTrue(isReports("reports"))
+        assertTrue(isReports("reports?startPage=1"))
+        assertFalse(isReports("english/dashboard"))
+    }
+
+    @Test
+    fun pyqpMatcher() {
+        assertTrue(isPyqp("english/pyqp"))
+        assertTrue(isPyqp("english/pyqp/42"))
+        assertFalse(isPyqp("english/concepts"))
+    }
+
+    @Test
+    fun analyticsMatcher() {
+        assertTrue(isAnalytics("analytics"))
+        assertTrue(isAnalytics("analytics/trend"))
+        assertFalse(isAnalytics("analysis/123"))
+    }
+
+    @Test
+    fun conceptsMatcher() {
+        assertTrue(isConcepts("english/concepts"))
+        assertTrue(isConcepts("english/concepts/2"))
+        assertFalse(isConcepts("quizHub"))
+    }
+}
+


### PR DESCRIPTION
## Summary
- precompute quiz resume progress and use derived states for dashboard
- memoize reports pager state and add tab click UI test
- add route matcher unit tests and PR template

## Testing
- `./gradlew ktlintCheck` *(fails: Task 'ktlintCheck' not found)*
- `./gradlew detekt` *(fails: Task 'detekt' not found)*
- `./gradlew :app:assembleDebug :app:testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew :app:connectedDebugAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895916a26108329a251d4366a42e740