### PR TITLE
Refactor navigation to top destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# CDS
+
+## Developer Setup
+
+Build and run unit tests:
+
+```
+./gradlew :app:assembleDebug :app:testDebugUnitTest
+```

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/components/BottomNavBar.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/components/BottomNavBar.kt
@@ -6,11 +6,11 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.concepts_and_quizzes.cds.core.config.RemoteConfig
 import com.concepts_and_quizzes.cds.core.navigation.BottomBarDestination
+import com.concepts_and_quizzes.cds.ui.nav.navigateToTop
 import com.concepts_and_quizzes.cds.ui.nav.isAnalytics
 import com.concepts_and_quizzes.cds.ui.nav.isConcepts
 import com.concepts_and_quizzes.cds.ui.nav.isPyqp
@@ -39,13 +39,7 @@ fun CdsBottomNavBar(
             NavigationBarItem(
                 selected = selected,
                 onClick = {
-                    navController.navigate(item.route) {
-                        popUpTo(navController.graph.findStartDestination().id) {
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
+                    navController.navigateToTop(item.route)
                 },
                 icon = { Icon(imageVector = item.icon, contentDescription = stringResource(id = item.label)) },
                 label = { Text(text = stringResource(id = item.label)) }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/components/NavigationRail.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/components/NavigationRail.kt
@@ -6,11 +6,11 @@ import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.concepts_and_quizzes.cds.core.config.RemoteConfig
 import com.concepts_and_quizzes.cds.core.navigation.BottomBarDestination
+import com.concepts_and_quizzes.cds.ui.nav.navigateToTop
 
 @Composable
 fun CdsNavigationRail(
@@ -35,13 +35,7 @@ fun CdsNavigationRail(
             NavigationRailItem(
                 selected = selected,
                 onClick = {
-                    navController.navigate(item.route) {
-                        popUpTo(navController.graph.findStartDestination().id) {
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
+                    navController.navigateToTop(item.route)
                 },
                 icon = { Icon(imageVector = item.icon, contentDescription = stringResource(id = item.label)) },
                 label = { Text(text = stringResource(id = item.label)) }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -57,6 +57,7 @@ import com.concepts_and_quizzes.cds.core.components.CdsCard
 import com.concepts_and_quizzes.cds.R
 import com.concepts_and_quizzes.cds.core.theme.Dimens
 import com.concepts_and_quizzes.cds.ui.english.quiz.QuizHubViewModel
+import com.concepts_and_quizzes.cds.ui.nav.navigateToTop
 import kotlinx.coroutines.launch
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -132,8 +133,8 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
             horizontalArrangement = Arrangement.spacedBy(Dimens.ChipSpacingX),
             verticalArrangement = Arrangement.spacedBy(Dimens.ChipSpacingX)
         ) {
-            ActionChip(Icons.Filled.AutoStories, "Concepts") { nav.navigate("english/concepts") }
-            ActionChip(Icons.Filled.School, "Mock Tests") { nav.navigate("quizHub") }
+            ActionChip(Icons.Filled.AutoStories, "Concepts") { nav.navigateToTop("english/concepts") }
+            ActionChip(Icons.Filled.School, "Mock Tests") { nav.navigateToTop("quizHub") }
             ActionChip(Icons.AutoMirrored.Filled.MenuBook, "Past Papers") { nav.navigate("english/pyqp") }
         }
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -47,6 +47,7 @@ import com.concepts_and_quizzes.cds.domain.english.PyqpQuestion
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import com.concepts_and_quizzes.cds.ui.quiz.PaletteBottomSheet
+import com.concepts_and_quizzes.cds.ui.nav.navigateToTop
 
 @Composable
 fun QuizScreen(
@@ -92,10 +93,7 @@ fun QuizScreen(
                 onDone = {
                     vm.saveProgress()
                     vm.dismissResult()
-                    nav.navigate("quizHub") {
-                        launchSingleTop = true
-                        popUpTo("english/pyqp/{paperId}") { inclusive = true }
-                    }
+                    nav.navigateToTop("quizHub")
                 },
                 onViewAnalytics = {
                     vm.saveProgress()

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import com.concepts_and_quizzes.cds.ui.nav.navigateToTop
 
 @HiltViewModel
 class QuizViewModel @Inject constructor(
@@ -376,10 +377,7 @@ class QuizViewModel @Inject constructor(
     }
 
     fun onSubmitSuccess(navController: NavController) {
-        navController.navigate("reports?analysisSessionId=$sessionId") {
-            popUpTo("practice") { inclusive = false }
-            launchSingleTop = true
-        }
+        navController.navigateToTop("reports?analysisSessionId=$sessionId")
     }
 
     private data class Section(

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/nav/NavExt.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/nav/NavExt.kt
@@ -1,0 +1,12 @@
+package com.concepts_and_quizzes.cds.ui.nav
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
+
+fun NavController.navigateToTop(route: String) {
+    navigate(route) {
+        popUpTo(graph.findStartDestination().id) { saveState = true }
+        launchSingleTop = true
+        restoreState = true
+    }
+}


### PR DESCRIPTION
## Summary
- Add `navigateToTop` NavController extension
- Use `navigateToTop` for Dashboard, Concepts, QuizHub, and Reports navigation
- Document Gradle build command in developer setup

## Testing
- `./gradlew :app:assembleDebug :app:testDebugUnitTest` *(fails: Android SDK Platform 36 and Build-Tools 35 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689598543c108329a78aa352dac25b8a