### PR TITLE
Type-safe startPage and persisted reports window

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
@@ -57,8 +57,11 @@ fun NavGraphBuilder.rootGraph(nav: NavHostController) {
     composable("analytics/peer") { PlaceholderAnalyticsScreen("Peer Percentile", nav) }
     composable("analytics/time") { PlaceholderAnalyticsScreen("Time Management", nav) }
     composable(
-        route = "reports?analysisSessionId={analysisSessionId}",
-        arguments = listOf(navArgument("analysisSessionId") { type = NavType.StringType; nullable = true })
+        route = "reports?analysisSessionId={analysisSessionId}&startPage={startPage}",
+        arguments = listOf(
+            navArgument("analysisSessionId") { type = NavType.StringType; nullable = true },
+            navArgument("startPage") { type = NavType.IntType; defaultValue = 0 }
+        )
     ) { backStack ->
         val sid = backStack.arguments?.getString("analysisSessionId")
         ReportsPagerScreen(navArgs = ReportsNavArgs(sid))

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsSharedViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsSharedViewModel.kt
@@ -12,14 +12,17 @@ enum class Window(val label: String) { D7("7D"), D30("30D"), LIFETIME("All") }
 
 @HiltViewModel
 class ReportsSharedViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
-    val startPage: Int = savedStateHandle.get<String>("startPage")?.toIntOrNull() ?: 0
+    val startPage: Int = savedStateHandle.get<Int>("startPage") ?: 0
 
-    private val _window = MutableStateFlow(Window.D7)
+    private val _window = MutableStateFlow(
+        savedStateHandle.get<Window>("reports_window") ?: Window.D7
+    )
     val window: StateFlow<Window> = _window.asStateFlow()
 
     fun setWindow(window: Window) {
         _window.value = window
+        savedStateHandle["reports_window"] = window
     }
 }


### PR DESCRIPTION
## Summary
- Declare `startPage` navigation arg as `NavType.IntType` with default 0
- Persist reports window selection via `SavedStateHandle`

## Testing
- `./gradlew test` *(fails: Android SDK components missing)*

------
https://chatgpt.com/codex/tasks/task_e_68959cc2fa70832997ef18348a553957