### PR TITLE
feat: harden report sharing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
@@ -1,8 +1,6 @@
 package com.concepts_and_quizzes.cds.ui.reports
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import android.content.Intent
-import android.graphics.Bitmap
 import android.graphics.Rect
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -38,15 +36,12 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.core.content.FileProvider
-import androidx.core.view.drawToBitmap
 import kotlinx.coroutines.launch
 import com.concepts_and_quizzes.cds.ui.reports.trend.TrendPage
 import com.concepts_and_quizzes.cds.ui.reports.heatmap.HeatMapPage
 import com.concepts_and_quizzes.cds.ui.reports.time.TimePage
 import com.concepts_and_quizzes.cds.ui.reports.peer.PeerPage
-import java.io.File
-import java.io.FileOutputStream
+import com.concepts_and_quizzes.cds.util.ShareUtils
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -71,25 +66,11 @@ fun ReportsScreen(
                 actions = {
                     IconButton(onClick = {
                         pagerRect?.let { rect ->
-                            val bitmap = view.drawToBitmap()
-                            val crop = Bitmap.createBitmap(bitmap, rect.left, rect.top, rect.width(), rect.height())
-                            val dir = File(context.cacheDir, "reports")
-                            dir.mkdirs()
-                            val file = File(dir, "report.png")
-                            FileOutputStream(file).use { out ->
-                                crop.compress(Bitmap.CompressFormat.PNG, 100, out)
-                            }
-                            val uri = FileProvider.getUriForFile(
-                                context,
-                                "${context.packageName}.provider",
-                                file
+                            ShareUtils.shareViewAsImage(
+                                context = context,
+                                view = view,
+                                rect = rect
                             )
-                            val intent = Intent(Intent.ACTION_SEND).apply {
-                                type = "image/png"
-                                putExtra(Intent.EXTRA_STREAM, uri)
-                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                            }
-                            context.startActivity(Intent.createChooser(intent, null))
                         }
                     }) {
                         Icon(Icons.Filled.Share, contentDescription = "Share")

--- a/app/src/main/java/com/concepts_and_quizzes/cds/util/ShareUtils.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/util/ShareUtils.kt
@@ -1,0 +1,35 @@
+package com.concepts_and_quizzes.cds.util
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Rect
+import android.view.View
+import androidx.core.content.FileProvider
+import androidx.core.view.drawToBitmap
+import java.io.File
+import java.io.FileOutputStream
+
+object ShareUtils {
+    fun shareViewAsImage(context: Context, view: View, rect: Rect) {
+        val fullBitmap = view.drawToBitmap()
+        val pageBitmap = Bitmap.createBitmap(fullBitmap, rect.left, rect.top, rect.width(), rect.height())
+        val dir = File(context.cacheDir, "composereports")
+        dir.mkdirs()
+        val file = File(dir, "report_${System.currentTimeMillis()}.png")
+        FileOutputStream(file).use { out ->
+            pageBitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.provider",
+            file
+        )
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "image/png"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        context.startActivity(Intent.createChooser(intent, null))
+    }
+}

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,3 @@
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="composereports" path="composereports/" />
+</paths>


### PR DESCRIPTION
## Summary
- share current reports via FileProvider with read permission
- move screenshot + share logic to ShareUtils
- declare FileProvider and cache path for report images

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a3809a148329bf49099948ae4a44