### PR TITLE
Unify UiState handling across lists and reports

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/components/States.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/components/States.kt
@@ -32,7 +32,7 @@ fun LoadingSkeleton() {
 fun EmptyState(
     title: String,
     actionLabel: String? = null,
-    onAction: (() -> Unit)? = null
+    onAction: (() -> Unit)? = null,
 ) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -48,15 +48,13 @@ fun EmptyState(
 @Composable
 fun ErrorState(
     message: String,
-    onRetry: (() -> Unit)?
+    onRetry: () -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(text = message, color = MaterialTheme.colorScheme.error)
-            if (onRetry != null) {
-                Spacer(Modifier.height(16.dp))
-                Button(onClick = onRetry) { Text("Retry") }
-            }
+            Spacer(Modifier.height(16.dp))
+            Button(onClick = onRetry) { Text("Retry") }
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -56,6 +56,10 @@ import androidx.compose.material3.ProgressIndicatorDefaults
 import com.concepts_and_quizzes.cds.core.components.CdsCard
 import com.concepts_and_quizzes.cds.R
 import com.concepts_and_quizzes.cds.core.theme.Dimens
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
+import com.concepts_and_quizzes.cds.ui.components.ErrorState
+import com.concepts_and_quizzes.cds.ui.components.LoadingSkeleton
+import com.concepts_and_quizzes.cds.ui.components.UiState
 import com.concepts_and_quizzes.cds.ui.english.quiz.QuizHubViewModel
 import com.concepts_and_quizzes.cds.ui.nav.navigateToTop
 import kotlinx.coroutines.launch
@@ -69,7 +73,7 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
     val savedProgress by resumeVm.progress.collectAsState()
     val summary by vm.summary.collectAsState()
     val questionsToday by vm.questionsToday.collectAsState()
-    val concepts by vm.tips.collectAsState()
+    val tipsState by vm.tips.collectAsState()
     val count by animateIntAsState(targetValue = questionsToday, label = "count")
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -194,7 +198,12 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
             style = MaterialTheme.typography.titleMedium
         )
 
-        DiscoverCarousel(concepts, vm, nav)
+        when (val s = tipsState) {
+            UiState.Loading -> LoadingSkeleton()
+            is UiState.Error -> ErrorState(s.message) { vm.refreshTips() }
+            is UiState.Empty -> EmptyState(s.title, s.actionLabel) { vm.refreshTips() }
+            is UiState.Data -> DiscoverCarousel(s.value, vm, nav)
+        }
     }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpListViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpListViewModel.kt
@@ -2,18 +2,40 @@ package com.concepts_and_quizzes.cds.ui.english.pyqp
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.concepts_and_quizzes.cds.data.english.repo.PyqpRepository
 import com.concepts_and_quizzes.cds.data.english.repo.PyqpPaper
+import com.concepts_and_quizzes.cds.data.english.repo.PyqpRepository
+import com.concepts_and_quizzes.cds.ui.components.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 
 @HiltViewModel
 class PyqpListViewModel @Inject constructor(
-    repo: PyqpRepository
+    private val repo: PyqpRepository,
 ) : ViewModel() {
-    val papers: StateFlow<List<PyqpPaper>> = repo.getPaperList()
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    private val _state = MutableStateFlow<UiState<List<PyqpPaper>>>(UiState.Loading)
+    val state: StateFlow<UiState<List<PyqpPaper>>> = _state
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        repo.getPaperList()
+            .onStart { _state.value = UiState.Loading }
+            .catch { _state.value = UiState.Error("Failed to load papers") }
+            .onEach { list ->
+                _state.value = if (list.isEmpty()) {
+                    UiState.Empty("No papers", "Reload")
+                } else {
+                    UiState.Data(list)
+                }
+            }
+            .launchIn(viewModelScope)
+    }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizPage.kt
@@ -10,14 +10,22 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.concepts_and_quizzes.cds.ui.components.EmptyState
+import com.concepts_and_quizzes.cds.ui.components.ErrorState
+import com.concepts_and_quizzes.cds.ui.components.LoadingSkeleton
+import com.concepts_and_quizzes.cds.ui.components.UiState
 import com.concepts_and_quizzes.cds.ui.english.analysis.AnalysisScreen
 
 @Composable
 fun LastQuizPage(sessionId: String?) {
     val vm: LastQuizViewModel = hiltViewModel()
     LaunchedEffect(sessionId) { vm.load(sessionId) }
-    val report by vm.report.collectAsState()
+    val state by vm.state.collectAsState()
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        report?.let { AnalysisScreen(it, vm.prefs) } ?: EmptyState(title = "No reports")
+        when (val s = state) {
+            UiState.Loading -> LoadingSkeleton()
+            is UiState.Error -> ErrorState(s.message) { vm.refresh() }
+            is UiState.Empty -> EmptyState(s.title, s.actionLabel) { vm.refresh() }
+            is UiState.Data -> AnalysisScreen(s.value, vm.prefs)
+        }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReport
 import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReportRepository
 import com.concepts_and_quizzes.cds.data.settings.UserPreferences
+import com.concepts_and_quizzes.cds.ui.components.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,13 +17,30 @@ class LastQuizViewModel @Inject constructor(
     private val repo: QuizReportRepository,
     val prefs: UserPreferences,
 ) : ViewModel() {
-    private val _report = MutableStateFlow<QuizReport?>(null)
-    val report: StateFlow<QuizReport?> = _report
+    private val _state = MutableStateFlow<UiState<QuizReport>>(UiState.Loading)
+    val state: StateFlow<UiState<QuizReport>> = _state
+
+    private var sessionId: String? = null
 
     fun load(sessionId: String?) {
+        this.sessionId = sessionId
+        refresh()
+    }
+
+    fun refresh() {
         viewModelScope.launch {
-            val sid = sessionId ?: repo.latestSessionId() ?: return@launch
-            _report.value = repo.analyse(sid)
+            _state.value = UiState.Loading
+            try {
+                val sid = sessionId ?: repo.latestSessionId()
+                if (sid == null) {
+                    _state.value = UiState.Empty("No reports", "Reload")
+                    return@launch
+                }
+                val report = repo.analyse(sid)
+                _state.value = UiState.Data(report)
+            } catch (e: Exception) {
+                _state.value = UiState.Error(e.message ?: "Failed to load report")
+            }
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/heatmap/HeatMapPage.kt
@@ -3,6 +3,8 @@ package com.concepts_and_quizzes.cds.ui.reports.heatmap
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -10,14 +12,28 @@ import androidx.lifecycle.ViewModel
 import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
 import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
 import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
+import com.concepts_and_quizzes.cds.ui.components.ErrorState
+import com.concepts_and_quizzes.cds.ui.components.LoadingSkeleton
+import com.concepts_and_quizzes.cds.ui.components.UiState
 import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
 import com.concepts_and_quizzes.cds.ui.skeleton.HeatmapSkeleton
-import com.concepts_and_quizzes.cds.ui.components.EmptyState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @HiltViewModel
-class HeatMapViewModel @Inject constructor() : ViewModel()
+class HeatMapViewModel @Inject constructor() : ViewModel() {
+    private val _state = MutableStateFlow<UiState<Unit>>(UiState.Loading)
+    val state: StateFlow<UiState<Unit>> = _state
+
+    init { refresh() }
+
+    fun refresh() {
+        _state.value = UiState.Empty("No heat map data", "Reload")
+    }
+}
 
 @Composable
 fun HeatMapPage(
@@ -29,12 +45,16 @@ fun HeatMapPage(
     ),
     vm: HeatMapViewModel = hiltViewModel()
 ) {
+    val state by vm.state.collectAsState()
     GhostOverlay(
         status = status,
         skeleton = { HeatmapSkeleton() },
     ) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            EmptyState(title = "No heat map data")
+        when (val s = state) {
+            UiState.Loading -> LoadingSkeleton()
+            is UiState.Error -> ErrorState(s.message) { vm.refresh() }
+            is UiState.Empty -> EmptyState(s.title, s.actionLabel) { vm.refresh() }
+            is UiState.Data -> Box(Modifier.fillMaxSize()) { }
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/peer/PeerPage.kt
@@ -3,20 +3,36 @@ package com.concepts_and_quizzes.cds.ui.reports.peer
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
 import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
+import com.concepts_and_quizzes.cds.ui.components.ErrorState
+import com.concepts_and_quizzes.cds.ui.components.LoadingSkeleton
+import com.concepts_and_quizzes.cds.ui.components.UiState
 import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
 import com.concepts_and_quizzes.cds.ui.skeleton.PeerSkeleton
-import com.concepts_and_quizzes.cds.ui.components.EmptyState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @HiltViewModel
-class PeerViewModel @Inject constructor() : ViewModel()
+class PeerViewModel @Inject constructor() : ViewModel() {
+    private val _state = MutableStateFlow<UiState<Unit>>(UiState.Loading)
+    val state: StateFlow<UiState<Unit>> = _state
+
+    init { refresh() }
+
+    fun refresh() {
+        _state.value = UiState.Empty("No peer data", "Reload")
+    }
+}
 
 @Composable
 fun PeerPage(
@@ -28,12 +44,16 @@ fun PeerPage(
     ),
     vm: PeerViewModel = hiltViewModel()
 ) {
+    val state by vm.state.collectAsState()
     GhostOverlay(
         status = status,
         skeleton = { PeerSkeleton() },
     ) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            EmptyState(title = "No peer data")
+        when (val s = state) {
+            UiState.Loading -> LoadingSkeleton()
+            is UiState.Error -> ErrorState(s.message) { vm.refresh() }
+            is UiState.Empty -> EmptyState(s.title, s.actionLabel) { vm.refresh() }
+            is UiState.Data -> Box(Modifier.fillMaxSize()) { }
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/time/TimePage.kt
@@ -3,6 +3,8 @@ package com.concepts_and_quizzes.cds.ui.reports.time
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -10,15 +12,29 @@ import androidx.lifecycle.ViewModel
 import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
 import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
 import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
+import com.concepts_and_quizzes.cds.ui.components.ErrorState
+import com.concepts_and_quizzes.cds.ui.components.LoadingSkeleton
+import com.concepts_and_quizzes.cds.ui.components.UiState
 import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
 import com.concepts_and_quizzes.cds.ui.skeleton.TimeSkeleton
-import com.concepts_and_quizzes.cds.ui.components.EmptyState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlin.time.Duration.Companion.hours
 
 @HiltViewModel
-class TimeViewModel @Inject constructor() : ViewModel()
+class TimeViewModel @Inject constructor() : ViewModel() {
+    private val _state = MutableStateFlow<UiState<Unit>>(UiState.Loading)
+    val state: StateFlow<UiState<Unit>> = _state
+
+    init { refresh() }
+
+    fun refresh() {
+        _state.value = UiState.Empty("No time data", "Reload")
+    }
+}
 
 @Composable
 fun TimePage(
@@ -30,12 +46,16 @@ fun TimePage(
     ),
     vm: TimeViewModel = hiltViewModel()
 ) {
+    val state by vm.state.collectAsState()
     GhostOverlay(
         status = status,
         skeleton = { TimeSkeleton() },
     ) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            EmptyState(title = "No time data")
+        when (val s = state) {
+            UiState.Loading -> LoadingSkeleton()
+            is UiState.Error -> ErrorState(s.message) { vm.refresh() }
+            is UiState.Empty -> EmptyState(s.title, s.actionLabel) { vm.refresh() }
+            is UiState.Data -> Box(Modifier.fillMaxSize()) { }
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/trend/TrendPage.kt
@@ -3,6 +3,8 @@ package com.concepts_and_quizzes.cds.ui.reports.trend
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -10,14 +12,28 @@ import androidx.lifecycle.ViewModel
 import com.concepts_and_quizzes.cds.data.analytics.unlock.AnalyticsModule
 import com.concepts_and_quizzes.cds.data.analytics.unlock.LockedReason
 import com.concepts_and_quizzes.cds.data.analytics.unlock.ModuleStatus
+import com.concepts_and_quizzes.cds.ui.components.EmptyState
+import com.concepts_and_quizzes.cds.ui.components.ErrorState
+import com.concepts_and_quizzes.cds.ui.components.LoadingSkeleton
+import com.concepts_and_quizzes.cds.ui.components.UiState
 import com.concepts_and_quizzes.cds.ui.reports.GhostOverlay
 import com.concepts_and_quizzes.cds.ui.skeleton.TrendSkeleton
-import com.concepts_and_quizzes.cds.ui.components.EmptyState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @HiltViewModel
-class TrendViewModel @Inject constructor() : ViewModel()
+class TrendViewModel @Inject constructor() : ViewModel() {
+    private val _state = MutableStateFlow<UiState<Unit>>(UiState.Loading)
+    val state: StateFlow<UiState<Unit>> = _state
+
+    init { refresh() }
+
+    fun refresh() {
+        _state.value = UiState.Empty("No trend data", "Reload")
+    }
+}
 
 @Composable
 fun TrendPage(
@@ -29,12 +45,16 @@ fun TrendPage(
     ),
     vm: TrendViewModel = hiltViewModel()
 ) {
+    val state by vm.state.collectAsState()
     GhostOverlay(
         status = status,
         skeleton = { TrendSkeleton() },
     ) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            EmptyState(title = "No trend data")
+        when (val s = state) {
+            UiState.Loading -> LoadingSkeleton()
+            is UiState.Error -> ErrorState(s.message) { vm.refresh() }
+            is UiState.Empty -> EmptyState(s.title, s.actionLabel) { vm.refresh() }
+            is UiState.Data -> Box(Modifier.fillMaxSize()) { }
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce non-null retry ErrorState and maintain Loading/Empty components
- wire Pyqp list, report pages, and dashboard tips to use UiState with refresh callbacks

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a579775c832992262ca1ee2ed79d