### PR TITLE
Optimize report pager and list performance

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
@@ -79,6 +79,7 @@ fun NavGraphBuilder.rootGraph(nav: NavHostController) {
     ) {
         val vm: AnalysisViewModel = hiltViewModel()
         val report by vm.report.collectAsState()
-        report?.let { AnalysisScreen(it, vm.prefs) }
+        val weakest by vm.weakest.collectAsState()
+        report?.let { AnalysisScreen(it, vm.prefs, weakest) }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/analytics/AnalyticsCatalogue.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/analytics/AnalyticsCatalogue.kt
@@ -47,7 +47,7 @@ fun AnalyticsCatalogue(statuses: List<ModuleStatus>, nav: NavController) {
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        items(statuses) { s ->
+        items(statuses, key = { it.module }) { s ->
             val alpha = if (s.unlocked) 1f else 0.3f
             Card(
                 modifier = Modifier
@@ -102,7 +102,7 @@ class AnalyticsCatalogueViewModel @Inject constructor(
     }
 
     fun refresh(stats: UnlockStats) {
-        _statuses.value = unlocker.statuses(stats)
+        _statuses.value = unlocker.statuses(stats).toList()
     }
 }
 

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -45,6 +44,7 @@ import android.net.Uri
 fun AnalysisScreen(
     report: QuizReport,
     prefs: UserPreferences,
+    weakestTopic: String?,
     nav: NavController? = null,
 ) {
     val showCelebrations by prefs.showCelebrations.collectAsState(initial = true)
@@ -54,15 +54,6 @@ fun AnalysisScreen(
     if (shouldCelebrate(report.accuracy) && showCelebrations) {
         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
         play = true
-    }
-
-    val weakest by remember(report) {
-        derivedStateOf {
-            val perfs = report.timePerSection.map {
-                TopicPerf(it.topicId.toString(), it.attempts, (it.accuracy * it.attempts / 100).toInt())
-            }
-            weakestTopic(perfs)
-        }
     }
 
     Box {
@@ -81,7 +72,7 @@ fun AnalysisScreen(
                     )
                 }
             }
-            weakest?.let { topic ->
+            weakestTopic?.let { topic ->
                 Column(verticalArrangement = spacedBy(8.dp)) {
                     Button(onClick = {
                         val encoded = Uri.encode(topic)
@@ -119,11 +110,5 @@ fun AnalysisScreen(
                 modifier = Modifier.fillMaxSize()
             )
         }
-    } 
+    }
 }
-
-data class TopicPerf(val topic: String, val attempts: Int, val correct: Int)
-
-private fun weakestTopic(items: List<TopicPerf>, minAttempts: Int = 6): String? =
-    items.filter { it.attempts >= minAttempts }
-        .minByOrNull { if (it.attempts == 0) 1.0 else it.correct.toDouble() / it.attempts }?.topic

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisUtils.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisUtils.kt
@@ -1,0 +1,14 @@
+package com.concepts_and_quizzes.cds.ui.english.analysis
+
+import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReport
+
+/**
+ * Returns the topic id (as string) of the weakest topic in the given report.
+ * Topics with fewer than [minAttempts] attempts are ignored to avoid noise.
+ */
+fun weakestTopic(report: QuizReport, minAttempts: Int = 6): String? =
+    report.timePerSection
+        .filter { it.attempts >= minAttempts }
+        .minByOrNull { it.accuracy }
+        ?.topicId
+        ?.toString()

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReport
 import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReportRepository
 import com.concepts_and_quizzes.cds.data.settings.UserPreferences
+import com.concepts_and_quizzes.cds.ui.english.analysis.weakestTopic
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,9 +23,14 @@ class AnalysisViewModel @Inject constructor(
     private val _report = MutableStateFlow<QuizReport?>(null)
     val report: StateFlow<QuizReport?> = _report
 
+    private val _weakest = MutableStateFlow<String?>(null)
+    val weakest: StateFlow<String?> = _weakest
+
     init {
         viewModelScope.launch {
-            _report.value = repo.analyse(sessionId)
+            val r = repo.analyse(sessionId)
+            _report.value = r
+            _weakest.value = weakestTopic(r)
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/concepts/ConceptsHomeScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/concepts/ConceptsHomeScreen.kt
@@ -33,13 +33,13 @@ fun ConceptsHomeScreen(nav: NavHostController, viewModel: ConceptsHomeViewModel 
         }
         if (selected.value == 0) {
             LazyColumn {
-                items(topics) { topic ->
+                items(topics, key = { it.id }) { topic ->
                     TopicCard(topic) { nav.navigate("english/concepts/${topic.id}") }
                 }
             }
         } else {
             LazyColumn {
-                items(bookmarks) { concept ->
+                items(bookmarks, key = { it.id }) { concept ->
                     BookmarkCard(concept) { nav.navigate("discover/${concept.id}") }
                 }
             }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/concepts/ConceptsHomeViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/concepts/ConceptsHomeViewModel.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel
@@ -18,8 +19,10 @@ class ConceptsHomeViewModel @Inject constructor(
     discoverRepo: DiscoverRepository
 ) : ViewModel() {
     val topics: StateFlow<List<EnglishTopic>> = repo.getTopics()
+        .map { it.toList() }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val bookmarks: StateFlow<List<ConceptEntity>> = discoverRepo.bookmarkedConcepts()
+        .map { it.toList() }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpListViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpListViewModel.kt
@@ -30,10 +30,11 @@ class PyqpListViewModel @Inject constructor(
             .onStart { _state.value = UiState.Loading }
             .catch { _state.value = UiState.Error("Failed to load papers") }
             .onEach { list ->
-                _state.value = if (list.isEmpty()) {
+                val copy = list.toList()
+                _state.value = if (copy.isEmpty()) {
                     UiState.Empty("No papers", "Reload")
                 } else {
-                    UiState.Data(list)
+                    UiState.Data(copy)
                 }
             }
             .launchIn(viewModelScope)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpPaperListScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/PyqpPaperListScreen.kt
@@ -29,7 +29,7 @@ fun PyqpPaperListScreen(nav: NavController, vm: PyqpListViewModel = hiltViewMode
         when (val s = state) {
             is UiState.Data -> {
                 LazyColumn(contentPadding = padd) {
-                    items(s.value) { paper ->
+                    items(s.value, key = { it.id }) { paper ->
                         ListItem(
                             headlineContent = { Text("CDS ${paper.year}  ${paper.id.takeLast(5)}") },
                             trailingContent = {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -209,7 +209,7 @@ private fun QuizPager(vm: QuizViewModel, state: QuizViewModel.QuizUi.Page) {
         strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
         )
         Spacer(Modifier.height(16.dp))
-        HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
+        HorizontalPager(state = pagerState, key = { it }, modifier = Modifier.weight(1f)) { page ->
             when (val p = vm.pageContent(page)) {
                 is QuizViewModel.QuizPage.Intro -> IntroPage(p)
                 is QuizViewModel.QuizPage.Question -> QuestionPage(

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
@@ -57,22 +57,23 @@ fun QuizHubScreen(nav: NavHostController, vm: QuizHubViewModel = hiltViewModel()
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text("Quiz Hub")
+            val modes = remember {
+                listOf(
+                    Mode("Full Paper", "Full past paper") { nav.navigate("english/pyqp?mode=FULL") },
+                    Mode("Topic", "Topic drill") {
+                        val topic = Uri.encode("t1")
+                        nav.navigate("english/pyqp?mode=TOPIC&topic=$topic")
+                    },
+                    Mode("Wrongs", "Retry mistakes") { nav.navigate("english/pyqp?mode=WRONGS") },
+                    Mode("Timed 20", "20Q sprint") { nav.navigate("english/pyqp?mode=TIMED20") },
+                    Mode("Mixed", "Mixed bag") { nav.navigate("english/pyqp?mode=MIXED") }
+                )
+            }
             LazyRow(
                 contentPadding = PaddingValues(vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                items(
-                    listOf(
-                        Mode("Full Paper", "Full past paper") { nav.navigate("english/pyqp?mode=FULL") },
-                        Mode("Topic", "Topic drill") {
-                            val topic = Uri.encode("t1")
-                            nav.navigate("english/pyqp?mode=TOPIC&topic=$topic")
-                        },
-                        Mode("Wrongs", "Retry mistakes") { nav.navigate("english/pyqp?mode=WRONGS") },
-                        Mode("Timed 20", "20Q sprint") { nav.navigate("english/pyqp?mode=TIMED20") },
-                        Mode("Mixed", "Mixed bag") { nav.navigate("english/pyqp?mode=MIXED") }
-                    )
-                ) { m ->
+                items(modes, key = { it.title }) { m ->
                     ModeCard(m)
                 }
             }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/onboarding/OnboardingScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -16,13 +18,16 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun OnboardingScreen(onFinish: () -> Unit) {
-    val pages = listOf(
-        "Dashboard helps track progress",
-        "Concepts contain study material",
-        "PYQP lets you practice exams"
-    )
+    val pages = remember {
+        listOf(
+            "Dashboard helps track progress",
+            "Concepts contain study material",
+            "PYQP lets you practice exams"
+        )
+    }
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { pages.size })
     val scope = rememberCoroutineScope()
+    val isLastPage by remember { derivedStateOf { pagerState.currentPage == pages.lastIndex } }
 
     Column(
         modifier = Modifier
@@ -30,14 +35,14 @@ fun OnboardingScreen(onFinish: () -> Unit) {
             .padding(24.dp),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
-        HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
+        HorizontalPager(state = pagerState, key = { pages[it] }, modifier = Modifier.weight(1f)) { page ->
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Text(pages[page])
             }
         }
         Button(
             onClick = {
-                if (pagerState.currentPage < pages.lastIndex) {
+                if (!isLastPage) {
                     scope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
                 } else {
                     onFinish()
@@ -45,7 +50,7 @@ fun OnboardingScreen(onFinish: () -> Unit) {
             },
             modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
-            Text(if (pagerState.currentPage == pages.lastIndex) "Start" else "Next")
+            Text(if (isLastPage) "Start" else "Next")
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/PaletteBottomSheet.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/PaletteBottomSheet.kt
@@ -43,8 +43,7 @@ fun PaletteBottomSheet(
                 columns = GridCells.Fixed(5),
                 modifier = Modifier.heightIn(max = 200.dp)
             ) {
-                items(entries.size) { idx ->
-                    val e = entries[idx]
+                items(entries, key = { it.questionIndex }) { e ->
                     val container = when {
                         e.flagged -> MaterialTheme.colorScheme.flaggedContainer
                         e.answered -> MaterialTheme.colorScheme.primaryContainer
@@ -61,7 +60,7 @@ fun PaletteBottomSheet(
                             .size(48.dp)
                             .background(container, RoundedCornerShape(8.dp))
                             .clickable { onSelect(e.questionIndex) },
-                        contentAlignment = Alignment.Center
+                        contentAlignment = Alignment.Center,
                     ) {
                         Text("${e.questionIndex + 1}", color = content)
                     }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionStatePalette.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/quiz/QuestionStatePalette.kt
@@ -38,8 +38,7 @@ fun QuestionStatePalette(
                     columns = GridCells.Fixed(5),
                     modifier = Modifier.heightIn(max = 200.dp)
                 ) {
-                    items(entries.size) { idx ->
-                        val e = entries[idx]
+                    items(entries, key = { it.questionIndex }) { e ->
                         val container = when {
                             e.flagged -> MaterialTheme.colorScheme.flaggedContainer
                             e.answered -> MaterialTheme.colorScheme.primaryContainer

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizPage.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizPage.kt
@@ -20,12 +20,13 @@ fun LastQuizPage(sessionId: String?) {
     val vm: LastQuizViewModel = hiltViewModel()
     LaunchedEffect(sessionId) { vm.load(sessionId) }
     val state by vm.state.collectAsState()
+    val weakest by vm.weakest.collectAsState()
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         when (val s = state) {
             UiState.Loading -> LoadingSkeleton()
             is UiState.Error -> ErrorState(s.message) { vm.refresh() }
             is UiState.Empty -> EmptyState(s.title, s.actionLabel) { vm.refresh() }
-            is UiState.Data -> AnalysisScreen(s.value, vm.prefs)
+            is UiState.Data -> AnalysisScreen(s.value, vm.prefs, weakest)
         }
     }
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/LastQuizViewModel.kt
@@ -6,6 +6,7 @@ import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReport
 import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReportRepository
 import com.concepts_and_quizzes.cds.data.settings.UserPreferences
 import com.concepts_and_quizzes.cds.ui.components.UiState
+import com.concepts_and_quizzes.cds.ui.english.analysis.weakestTopic
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,6 +20,9 @@ class LastQuizViewModel @Inject constructor(
 ) : ViewModel() {
     private val _state = MutableStateFlow<UiState<QuizReport>>(UiState.Loading)
     val state: StateFlow<UiState<QuizReport>> = _state
+
+    private val _weakest = MutableStateFlow<String?>(null)
+    val weakest: StateFlow<String?> = _weakest
 
     private var sessionId: String? = null
 
@@ -37,6 +41,7 @@ class LastQuizViewModel @Inject constructor(
                     return@launch
                 }
                 val report = repo.analyse(sid)
+                _weakest.value = weakestTopic(report)
                 _state.value = UiState.Data(report)
             } catch (e: Exception) {
                 _state.value = UiState.Error(e.message ?: "Failed to load report")

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
@@ -105,6 +105,7 @@ fun ReportsScreen(
             }
             VerticalPager(
                 state = pagerState,
+                key = { it },
                 modifier = Modifier
                     .weight(1f)
                     .testTag("reportsPager")


### PR DESCRIPTION
## Summary
- pre-compute weakest topic in report view models
- return immutable lists and add stable keys to concept and paper lists
- key pager pages and remember derived state to reduce recompositions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b727a048832990d6de4e14835963