### PR TITLE
Fix PYQP quiz submission navigation

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -401,7 +401,7 @@ class QuizViewModel @Inject constructor(
 
     fun onSubmitSuccess(navController: NavController) {
         Telemetry.logAnalysisCta(sessionId)
-        navController.navigateToTop("reports?analysisSessionId=$sessionId")
+        navController.navigateToTop("reports?analysisSessionId=$sessionId&startPage=0")
     }
 
     private data class Section(

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizSubmitNavigationTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizSubmitNavigationTest.kt
@@ -102,6 +102,7 @@ class QuizSubmitNavigationTest {
 
         vm.onSubmitSuccess(nav)
         assertTrue(nav.route!!.startsWith("reports?analysisSessionId="))
+        assertTrue(nav.route!!.contains("&startPage=0"))
     }
 }
 


### PR DESCRIPTION
## Summary
- navigate to analysis reports with explicit start page after quiz submission
- assert startPage query in QuizSubmitNavigationTest

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895e290bafc83298c6b55ced32a87d8