### PR TITLE
Navigate to analysis after PYQ submission

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizScreen.kt
@@ -86,7 +86,7 @@ fun QuizScreen(
         }
     }
 
-    if (showResult) {
+    if (showResult && !navigatingToAnalysis) {
         result?.let { r ->
             ResultView(
                 r,
@@ -244,7 +244,13 @@ private fun QuizPager(vm: QuizViewModel, state: QuizViewModel.QuizUi.Page) {
         AlertDialog(
             onDismissRequest = { showSubmit = false },
             confirmButton = {
-                TextButton(onClick = { showSubmit = false; vm.submitQuiz() }) { Text("Submit") }
+                TextButton(onClick = {
+                    showSubmit = false
+                    vm.submitQuiz()
+                    vm.saveProgress()
+                    vm.dismissResult()
+                    navigatingToAnalysis = true
+                }) { Text("Submit") }
             },
             dismissButton = {
                 TextButton(onClick = { showSubmit = false }) { Text("Cancel") }


### PR DESCRIPTION
## Summary
- Navigate straight to quiz analysis after confirming submission in PYQ quiz
- Suppress result dialog when redirecting

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895e8d69574832981584c23cedc4299