### PR TITLE
Implement mode availability and coming soon flow

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/availability/ModeAvailability.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/availability/ModeAvailability.kt
@@ -1,0 +1,24 @@
+package com.concepts_and_quizzes.cds.data.analytics.availability
+
+import javax.inject.Inject
+import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
+
+
+data class ModeAvailability(
+    val wrongOnlyAvailable: Boolean,
+    val timed20Available: Boolean,
+    val mixedAvailable: Boolean
+)
+
+class ModeAvailabilityRepository @Inject constructor(
+    private val attemptLogDao: AttemptLogDao
+) {
+    suspend fun fetch(): ModeAvailability {
+        val wrongCount = attemptLogDao.countWrongAnswers()
+        return ModeAvailability(
+            wrongOnlyAvailable = wrongCount > 0,
+            timed20Available = false,
+            mixedAvailable = false
+        )
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
@@ -21,6 +21,9 @@ interface AttemptLogDao {
     @Query("SELECT * FROM attempt_log WHERE sessionId = :sid ORDER BY questionIndex")
     suspend fun forSession(sid: String): List<AttemptLogEntity>
 
+    @Query("SELECT COUNT(*) FROM attempt_log WHERE correct = 0")
+    suspend fun countWrongAnswers(): Int
+
     @Query(
         """
         SELECT a.qid

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/common/ComingSoonScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/common/ComingSoonScreen.kt
@@ -1,0 +1,29 @@
+package com.concepts_and_quizzes.cds.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ComingSoonScreen(title: String, body: String) {
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            Modifier
+                .align(Alignment.Center)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(title, style = MaterialTheme.typography.titleLarge)
+            Spacer(Modifier.height(12.dp))
+            Text(body, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/common/ModeAvailabilityViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/common/ModeAvailabilityViewModel.kt
@@ -1,0 +1,23 @@
+package com.concepts_and_quizzes.cds.ui.common
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.concepts_and_quizzes.cds.data.analytics.availability.ModeAvailability
+import com.concepts_and_quizzes.cds.data.analytics.availability.ModeAvailabilityRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ModeAvailabilityViewModel @Inject constructor(
+    private val repo: ModeAvailabilityRepository
+) : ViewModel() {
+    private val _availability = MutableStateFlow<ModeAvailability?>(null)
+    val availability: StateFlow<ModeAvailability?> = _availability
+
+    init {
+        viewModelScope.launch { _availability.value = repo.fetch() }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/common/ModeCard.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/common/ModeCard.kt
@@ -1,0 +1,44 @@
+package com.concepts_and_quizzes.cds.ui.common
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ModeCard(
+    title: String,
+    subtitle: String? = null,
+    enabled: Boolean,
+    disabledCaption: String? = null,
+    onClick: () -> Unit
+) {
+    val colours = if (enabled) CardDefaults.cardColors() else
+        CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    Card(
+        onClick = { if (enabled) onClick() },
+        enabled = enabled,
+        colors = colours,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            if (subtitle != null) Text(subtitle, style = MaterialTheme.typography.bodySmall)
+            if (!enabled && disabledCaption != null) {
+                Spacer(Modifier.height(8.dp))
+                Text(disabledCaption, style = MaterialTheme.typography.labelSmall)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/analysis/AnalysisScreen.kt
@@ -81,7 +81,7 @@ fun AnalysisScreen(
                         Text("Retake weakest topic")
                     }
                     OutlinedButton(onClick = {
-                        nav?.navigate("english/pyqp?mode=MIXED")
+                        nav?.navigate("comingSoon/mixed")
                     }) {
                         Text("10 from weak areas")
                     }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -3,62 +3,47 @@ package com.concepts_and_quizzes.cds.ui.english.dashboard
 import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Article
-import androidx.compose.material.icons.filled.QuestionAnswer
-import androidx.compose.material.icons.filled.Replay
-import androidx.compose.material.icons.filled.Shuffle
-import androidx.compose.material.icons.filled.Timer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import java.time.LocalTime
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.animateIntAsState
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ProgressIndicatorDefaults
-import androidx.compose.ui.res.stringResource
 import com.concepts_and_quizzes.cds.R
 import com.concepts_and_quizzes.cds.core.components.CdsCard
 import com.concepts_and_quizzes.cds.core.theme.Dimens
+import com.concepts_and_quizzes.cds.ui.common.ModeCard
 import com.concepts_and_quizzes.cds.ui.components.EmptyState
 import com.concepts_and_quizzes.cds.ui.components.ErrorState
 import com.concepts_and_quizzes.cds.ui.components.LoadingSkeleton
@@ -67,7 +52,7 @@ import com.concepts_and_quizzes.cds.ui.english.quiz.QuizHubViewModel
 import kotlinx.coroutines.launch
 
 @RequiresApi(Build.VERSION_CODES.O)
-@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel = hiltViewModel()) {
     val resumeVm: QuizHubViewModel = hiltViewModel()
@@ -75,6 +60,7 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
     val savedProgress by resumeVm.progress.collectAsState()
     val summary by vm.summary.collectAsState()
     val questionsToday by vm.questionsToday.collectAsState()
+    val availability = vm.availability.collectAsState().value
     val tipsState by vm.tips.collectAsState()
     val count by animateIntAsState(targetValue = questionsToday, label = "count")
     val snackbarHostState = remember { SnackbarHostState() }
@@ -165,28 +151,33 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
             }
         }
 
-        FlowRow(
-            modifier = Modifier
-                .padding(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(Dimens.ChipSpacingX),
-            verticalArrangement = Arrangement.spacedBy(Dimens.ChipSpacingX)
-        ) {
-            val topic = Uri.encode("t1")
-            ActionChip(Icons.Filled.Article, stringResource(R.string.quick_topic)) {
-                nav.navigate("english/pyqp?mode=TOPIC&topic=$topic")
+        availability?.let { avail ->
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                ModeCard(
+                    title = stringResource(R.string.wrong_only_title),
+                    subtitle = stringResource(R.string.wrong_only_sub),
+                    enabled = avail.wrongOnlyAvailable,
+                    disabledCaption = stringResource(R.string.wrong_only_disabled)
+                ) {
+                    nav.navigate("english/pyqp?mode=WRONGS")
+                }
+                ModeCard(
+                    title = stringResource(R.string.timed20_title),
+                    subtitle = stringResource(R.string.timed20_sub),
+                    enabled = false
+                ) { nav.navigate("comingSoon/timed20") }
+                ModeCard(
+                    title = stringResource(R.string.mixed_title),
+                    subtitle = stringResource(R.string.coming_soon_title),
+                    enabled = false
+                ) { nav.navigate("comingSoon/mixed") }
             }
-            ActionChip(Icons.Filled.Replay, stringResource(R.string.quick_wrong_only)) {
-                nav.navigate("english/pyqp?mode=WRONGS")
-            }
-            ActionChip(Icons.Filled.Timer, stringResource(R.string.quick_timed_20)) {
-                nav.navigate("english/pyqp?mode=TIMED20")
-            }
-            ActionChip(Icons.Filled.Shuffle, stringResource(R.string.quick_mixed)) {
-                nav.navigate("english/pyqp?mode=MIXED")
-            }
+            Spacer(Modifier.height(16.dp))
         }
-
-        Spacer(Modifier.height(16.dp))
 
         Row(
             Modifier
@@ -228,34 +219,6 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
     }
     }
 }
-
-@Composable
-private fun ActionChip(icon: ImageVector, label: String, onClick: () -> Unit) {
-    val interaction = remember { MutableInteractionSource() }
-    val pressed by interaction.collectIsPressedAsState()
-    val scale by animateFloatAsState(targetValue = if (pressed) 0.95f else 1f, label = "scale")
-
-    Surface(
-        modifier = Modifier
-            .graphicsLayer {
-                scaleX = scale
-                scaleY = scale
-            }
-            .clickable(interactionSource = interaction, indication = null, onClick = onClick),
-        shape = MaterialTheme.shapes.small,
-        color = MaterialTheme.colorScheme.secondaryContainer
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(icon, contentDescription = null)
-            Spacer(Modifier.width(8.dp))
-            Text(label)
-        }
-    }
-}
-
 @Composable
 private fun MiniTrendCard(modifier: Modifier = Modifier, onClick: () -> Unit) {
     CdsCard(modifier = modifier, onClick = onClick) {

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
@@ -1,39 +1,21 @@
 package com.concepts_and_quizzes.cds.ui.english.quiz
 
 import android.net.Uri
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Article
-import androidx.compose.material.icons.filled.Replay
-import androidx.compose.material.icons.filled.Shuffle
-import androidx.compose.material.icons.filled.Timer
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -41,12 +23,12 @@ import androidx.navigation.NavHostController
 import com.concepts_and_quizzes.cds.R
 import com.concepts_and_quizzes.cds.core.components.CdsCard
 import com.concepts_and_quizzes.cds.core.theme.Dimens
-import androidx.compose.ui.graphics.vector.ImageVector
+import com.concepts_and_quizzes.cds.ui.common.ModeCard
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun QuizHubScreen(nav: NavHostController, vm: QuizHubViewModel = hiltViewModel()) {
     val store by vm.store.collectAsState()
+    val availability = vm.availability.collectAsState().value
     val snackbarHostState = remember { SnackbarHostState() }
     val resumePrompt = stringResource(R.string.continue_last_quiz)
     val continueLabel = stringResource(R.string.continue_action)
@@ -78,23 +60,23 @@ fun QuizHubScreen(nav: NavHostController, vm: QuizHubViewModel = hiltViewModel()
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text("Quiz Hub")
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(Dimens.ChipSpacingX),
-                verticalArrangement = Arrangement.spacedBy(Dimens.ChipSpacingX)
-            ) {
-                val topic = Uri.encode("t1")
-                ActionChip(Icons.Filled.Article, stringResource(R.string.quick_topic)) {
-                    nav.navigate("english/pyqp?mode=TOPIC&topic=$topic")
-                }
-                ActionChip(Icons.Filled.Replay, stringResource(R.string.quick_wrong_only)) {
-                    nav.navigate("english/pyqp?mode=WRONGS")
-                }
-                ActionChip(Icons.Filled.Timer, stringResource(R.string.quick_timed_20)) {
-                    nav.navigate("english/pyqp?mode=TIMED20")
-                }
-                ActionChip(Icons.Filled.Shuffle, stringResource(R.string.quick_mixed)) {
-                    nav.navigate("english/pyqp?mode=MIXED")
-                }
+            availability?.let { avail ->
+                ModeCard(
+                    title = stringResource(R.string.wrong_only_title),
+                    subtitle = stringResource(R.string.wrong_only_sub),
+                    enabled = avail.wrongOnlyAvailable,
+                    disabledCaption = stringResource(R.string.wrong_only_disabled)
+                ) { nav.navigate("english/pyqp?mode=WRONGS") }
+                ModeCard(
+                    title = stringResource(R.string.timed20_title),
+                    subtitle = stringResource(R.string.timed20_sub),
+                    enabled = false
+                ) { nav.navigate("comingSoon/timed20") }
+                ModeCard(
+                    title = stringResource(R.string.mixed_title),
+                    subtitle = stringResource(R.string.coming_soon_title),
+                    enabled = false
+                ) { nav.navigate("comingSoon/mixed") }
             }
             CdsCard {
                 Column(
@@ -106,33 +88,6 @@ fun QuizHubScreen(nav: NavHostController, vm: QuizHubViewModel = hiltViewModel()
                 }
             }
     }
-    }
-}
-
-@Composable
-private fun ActionChip(icon: ImageVector, label: String, onClick: () -> Unit) {
-    val interaction = remember { MutableInteractionSource() }
-    val pressed by interaction.collectIsPressedAsState()
-    val scale by animateFloatAsState(targetValue = if (pressed) 0.95f else 1f, label = "scale")
-
-    Surface(
-        modifier = Modifier
-            .graphicsLayer {
-                scaleX = scale
-                scaleY = scale
-            }
-            .clickable(interactionSource = interaction, indication = null, onClick = onClick),
-        shape = MaterialTheme.shapes.small,
-        color = MaterialTheme.colorScheme.secondaryContainer
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(icon, contentDescription = null)
-            Spacer(Modifier.width(8.dp))
-            Text(label)
-        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,14 @@
     <string name="quick_wrong_only">Wrong-only</string>
     <string name="quick_timed_20">Timed 20</string>
     <string name="quick_mixed">Mixed</string>
+    <string name="wrong_only_title">Wrong-only</string>
+    <string name="wrong_only_sub">Practise questions you got wrong</string>
+    <string name="wrong_only_disabled">No wrong answers yet. Attempt a quiz first.</string>
+    <string name="timed20_title">Timed 20</string>
+    <string name="timed20_sub">20 questions against the clock</string>
+    <string name="mixed_title">Mixed</string>
+    <string name="coming_soon_title">Coming soon</string>
+    <string name="coming_soon_body_generic">This feature will be available shortly.</string>
+    <string name="coming_soon_body_timed20">Timed 20 will be available shortly.</string>
+    <string name="coming_soon_body_mixed">Mixed practice will be available shortly.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add DAO count for wrong answers and mode availability repository
- introduce reusable ModeCard and ComingSoon screen
- wire Dashboard, QuizHub and navigation to respect mode availability and guard unimplemented modes

## Testing
- `./gradlew :app:assembleDebug :app:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960874c34483298f92b0997e0ea8a2