### PR TITLE
Reset bottom nav destinations

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/nav/NavExt.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/nav/NavExt.kt
@@ -5,8 +5,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 
 fun NavController.navigateToTop(route: String) {
     navigate(route) {
-        popUpTo(graph.findStartDestination().id) { saveState = true }
+        popUpTo(graph.findStartDestination().id)
         launchSingleTop = true
-        restoreState = true
     }
 }

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/nav/NavExtTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/nav/NavExtTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.composable
 import androidx.navigation.createGraph
+import androidx.navigation.navArgument
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -27,5 +28,28 @@ class NavExtTest {
 
         val count = controller.backQueue.count { it.destination.route == "target" }
         assertEquals(1, count)
+    }
+
+    @Test
+    fun navigateToTopUsesLatestArguments() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val controller = TestNavHostController(context)
+        controller.navigatorProvider.addNavigator(ComposeNavigator())
+        controller.setGraph(
+            controller.navigatorProvider.createGraph(startDestination = "home") {
+                composable("home") {}
+                composable(
+                    route = "target?arg={arg}",
+                    arguments = listOf(androidx.navigation.navArgument("arg") { defaultValue = "first" })
+                ) {}
+            }
+        )
+
+        controller.navigate("target?arg=first")
+        controller.navigateToTop("home")
+        controller.navigateToTop("target?arg=second")
+
+        val arg = controller.currentBackStackEntry?.arguments?.getString("arg")
+        assertEquals("second", arg)
     }
 }


### PR DESCRIPTION
## Summary
- stop restoring saved state when jumping between bottom bar tabs
- add test ensuring latest arguments are used after reselection

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960d9803a883298175c52bc60b7f19