### PR TITLE
Fix wrong-only quiz generation without topic

### DIFF
--- a/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/english/pyqp/ResumeFlowUiTest.kt
+++ b/app/src/androidTest/java/com/concepts_and_quizzes/cds/ui/english/pyqp/ResumeFlowUiTest.kt
@@ -58,6 +58,7 @@ class ResumeFlowUiTest {
             override suspend fun upsertAll(rows: List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity>) {}
             override suspend fun forSession(sid: String): List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity> = emptyList()
             override suspend fun latestWrongQids(topicId: String) = emptyList<String>()
+            override suspend fun latestWrongQids() = emptyList<String>()
             override fun getTrend(startTime: Long) = kotlinx.coroutines.flow.flowOf(emptyList<TopicTrendPointDb>())
             override fun getDifficulty() = kotlinx.coroutines.flow.flowOf(emptyList<TopicDifficultyDb>())
             override fun getAttemptsWithScore() = kotlinx.coroutines.flow.flowOf(emptyList<com.concepts_and_quizzes.cds.data.analytics.db.AttemptWithScoreDb>())

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
@@ -40,6 +40,21 @@ interface AttemptLogDao {
     )
     suspend fun latestWrongQids(topicId: String): List<String>
 
+    @Query(
+        """
+        SELECT a.qid
+        FROM attempt_log a
+        JOIN pyqp_questions q ON a.qid = q.qid
+        WHERE a.timestamp = (
+            SELECT MAX(a2.timestamp)
+            FROM attempt_log a2
+            WHERE a2.qid = a.qid
+        )
+          AND a.correct = 0
+        """
+    )
+    suspend fun latestWrongQids(): List<String>
+
     // --- Trend over time ---
     @Query(
         """

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/repo/PyqpRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/repo/PyqpRepository.kt
@@ -37,8 +37,12 @@ class PyqpRepository @Inject constructor(
             }
         }
 
-    suspend fun wrongOnlyQuestions(topicId: String): List<PyqpQuestion> {
-        val qids = attemptDao.latestWrongQids(topicId)
+    suspend fun wrongOnlyQuestions(topicId: String? = null): List<PyqpQuestion> {
+        val qids = if (topicId != null) {
+            attemptDao.latestWrongQids(topicId)
+        } else {
+            attemptDao.latestWrongQids()
+        }
         if (qids.isEmpty()) return emptyList()
         return dao.getQuestionsByIds(qids).map { e ->
             PyqpQuestion(

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -127,8 +127,13 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
                     .fillMaxWidth()
                     .clickable {
                         val dest = if (s.paperId.startsWith("WRONGS:")) {
-                            val topic = Uri.encode(s.paperId.removePrefix("WRONGS:"))
-                            "english/pyqp?mode=WRONGS&topic=$topic"
+                            val topic = s.paperId.removePrefix("WRONGS:")
+                            if (topic.isNotEmpty()) {
+                                val enc = Uri.encode(topic)
+                                "english/pyqp?mode=WRONGS&topic=$enc"
+                            } else {
+                                "english/pyqp?mode=WRONGS"
+                            }
                         } else {
                             "english/pyqp/${s.paperId}"
                         }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModel.kt
@@ -86,8 +86,7 @@ class QuizViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             if (mode == "WRONGS") {
-                val t = topic ?: return@launch
-                val qs = repo.wrongOnlyQuestions(t)
+                val qs = repo.wrongOnlyQuestions(topic?.takeIf { it.isNotEmpty() })
                 questions = qs
                 if (qs.isNotEmpty()) {
                     buildPages(qs)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
@@ -40,8 +40,13 @@ fun QuizHubScreen(nav: NavHostController, vm: QuizHubViewModel = hiltViewModel()
             )
             if (result == SnackbarResult.ActionPerformed) {
                 val dest = if (s.paperId.startsWith("WRONGS:")) {
-                    val topic = Uri.encode(s.paperId.removePrefix("WRONGS:"))
-                    "english/pyqp?mode=WRONGS&topic=$topic"
+                    val topic = s.paperId.removePrefix("WRONGS:")
+                    if (topic.isNotEmpty()) {
+                        val enc = Uri.encode(topic)
+                        "english/pyqp?mode=WRONGS&topic=$enc"
+                    } else {
+                        "english/pyqp?mode=WRONGS"
+                    }
                 } else {
                     "english/pyqp/${s.paperId}"
                 }

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizSubmitNavigationTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizSubmitNavigationTest.kt
@@ -66,6 +66,7 @@ class QuizSubmitNavigationTest {
             override suspend fun upsertAll(rows: List<AttemptLogEntity>) {}
             override suspend fun forSession(sid: String): List<AttemptLogEntity> = emptyList()
             override suspend fun latestWrongQids(topicId: String): List<String> = emptyList()
+            override suspend fun latestWrongQids(): List<String> = emptyList()
             override fun getTrend(startTime: Long): Flow<List<TopicTrendPointDb>> = flowOf(emptyList())
             override fun getDifficulty(): Flow<List<TopicDifficultyDb>> = flowOf(emptyList())
             override fun getAttemptsWithScore(): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptWithScoreDb>> =

--- a/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/ui/english/pyqp/QuizViewModelTest.kt
@@ -75,6 +75,7 @@ class QuizViewModelTest {
             }
             override suspend fun forSession(sid: String): List<AttemptLogEntity> = emptyList()
             override suspend fun latestWrongQids(topicId: String): List<String> = emptyList()
+            override suspend fun latestWrongQids(): List<String> = emptyList()
             override fun getTrend(startTime: Long): Flow<List<TopicTrendPointDb>> = flowOf(emptyList())
             override fun getDifficulty(): Flow<List<TopicDifficultyDb>> = flowOf(emptyList())
             override fun getAttemptsWithScore(): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptWithScoreDb>> = flowOf(emptyList())
@@ -137,7 +138,8 @@ class QuizViewModelTest {
             override suspend fun insertAll(attempts: List<AttemptLogEntity>) {}
             override suspend fun upsertAll(rows: List<AttemptLogEntity>) {}
             override suspend fun forSession(sid: String): List<AttemptLogEntity> = emptyList()
-            override suspend fun latestWrongQids(topicId: String): List<String> = listOf("q1", "q2")
+            override suspend fun latestWrongQids(topicId: String): List<String> = emptyList()
+            override suspend fun latestWrongQids(): List<String> = listOf("q1", "q2")
             override fun getTrend(startTime: Long): Flow<List<TopicTrendPointDb>> = flowOf(emptyList())
             override fun getDifficulty(): Flow<List<TopicDifficultyDb>> = flowOf(emptyList())
             override fun getAttemptsWithScore(): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptWithScoreDb>> = flowOf(emptyList())
@@ -161,7 +163,7 @@ class QuizViewModelTest {
             analytics,
             reportRepo,
             QuizResumeStore(context),
-            SavedStateHandle(mapOf("mode" to "WRONGS", "topic" to "grammar"))
+            SavedStateHandle(mapOf("mode" to "WRONGS"))
         )
         advanceUntilIdle()
         assertEquals(2, vm.questionCount)
@@ -185,6 +187,7 @@ class QuizViewModelTest {
             override suspend fun upsertAll(rows: List<AttemptLogEntity>) {}
             override suspend fun forSession(sid: String): List<AttemptLogEntity> = emptyList()
             override suspend fun latestWrongQids(topicId: String): List<String> = emptyList()
+            override suspend fun latestWrongQids(): List<String> = emptyList()
             override fun getTrend(startTime: Long): Flow<List<TopicTrendPointDb>> = flowOf(emptyList())
             override fun getDifficulty(): Flow<List<TopicDifficultyDb>> = flowOf(emptyList())
             override fun getAttemptsWithScore(): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptWithScoreDb>> = flowOf(emptyList())
@@ -230,6 +233,7 @@ class QuizViewModelTest {
             override suspend fun upsertAll(rows: List<AttemptLogEntity>) {}
             override suspend fun forSession(sid: String): List<AttemptLogEntity> = emptyList()
             override suspend fun latestWrongQids(topicId: String): List<String> = emptyList()
+            override suspend fun latestWrongQids(): List<String> = emptyList()
             override fun getTrend(startTime: Long): Flow<List<TopicTrendPointDb>> = flowOf(emptyList())
             override fun getDifficulty(): Flow<List<TopicDifficultyDb>> = flowOf(emptyList())
             override fun getAttemptsWithScore(): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptWithScoreDb>> =
@@ -285,6 +289,7 @@ class QuizViewModelTest {
             override suspend fun upsertAll(rows: List<AttemptLogEntity>) {}
             override suspend fun forSession(sid: String): List<AttemptLogEntity> = emptyList()
             override suspend fun latestWrongQids(topicId: String): List<String> = emptyList()
+            override suspend fun latestWrongQids(): List<String> = emptyList()
             override fun getTrend(startTime: Long): Flow<List<TopicTrendPointDb>> = flowOf(emptyList())
             override fun getDifficulty(): Flow<List<TopicDifficultyDb>> = flowOf(emptyList())
             override fun getAttemptsWithScore(): Flow<List<com.concepts_and_quizzes.cds.data.analytics.db.AttemptWithScoreDb>> = flowOf(emptyList())


### PR DESCRIPTION
## Summary
- allow fetching latest wrong answers without specifying a topic
- load wrong-only quiz even when no topic is provided
- handle empty-topic resume navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689612bd318c83299be1c04187d3d9fd