### PR TITLE
Add PYQ practice entry

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -168,6 +168,13 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 ModeCard(
+                    title = stringResource(R.string.pyqp_title),
+                    subtitle = stringResource(R.string.pyqp_sub),
+                    enabled = true
+                ) {
+                    nav.navigate("english/pyqp")
+                }
+                ModeCard(
                     title = stringResource(R.string.wrong_only_title),
                     subtitle = stringResource(R.string.wrong_only_sub),
                     enabled = avail.wrongOnlyAvailable,

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/quiz/QuizHubScreen.kt
@@ -65,6 +65,11 @@ fun QuizHubScreen(nav: NavHostController, vm: QuizHubViewModel = hiltViewModel()
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text("Quiz Hub")
+            ModeCard(
+                title = stringResource(R.string.pyqp_title),
+                subtitle = stringResource(R.string.pyqp_sub),
+                enabled = true
+            ) { nav.navigate("english/pyqp") }
             availability?.let { avail ->
                 ModeCard(
                     title = stringResource(R.string.wrong_only_title),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="quick_wrong_only">Wrong-only</string>
     <string name="quick_timed_20">Timed 20</string>
     <string name="quick_mixed">Mixed</string>
+    <string name="pyqp_title">Past Papers</string>
+    <string name="pyqp_sub">Attempt full CDS exam papers</string>
     <string name="wrong_only_title">Wrong-only</string>
     <string name="wrong_only_sub">Practise questions you got wrong</string>
     <string name="wrong_only_disabled">No wrong answers yet. Attempt a quiz first.</string>


### PR DESCRIPTION
## Summary
- add "Past Papers" mode card to Quiz Hub and Dashboard
- define string resources for new Past Papers option

## Testing
- `./gradlew :app:assembleDebug :app:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689636455d2483298ba4e96585cd60bb