### PR TITLE
Fix DashboardTile call in EnglishDashboardScreen

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/english/dashboard/EnglishDashboardScreen.kt
@@ -138,6 +138,14 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
                     DashboardTile(
                         title = stringResource(R.string.continue_quiz),
                         subtitle = prog?.let { "${it.percent}%" },
+                        content = {
+                            prog?.let { p ->
+                                LinearProgressIndicator(
+                                    progress = p.percent / 100f,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                        },
                         onClick = {
                             val dest = if (s.paperId.startsWith("WRONGS:")) {
                                 val topic = s.paperId.removePrefix("WRONGS:")
@@ -152,15 +160,8 @@ fun EnglishDashboardScreen(nav: NavHostController, vm: EnglishDashboardViewModel
                             }
                             scope.launch { snackbarHostState.showSnackbar("Resumed") }
                             nav.navigate(dest)
-                        }
-                    ) {
-                        prog?.let { p ->
-                            LinearProgressIndicator(
-                                progress = p.percent / 100f,
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
-                    }
+                        },
+                    )
                 }
             }
 


### PR DESCRIPTION
## Summary
- Correct DashboardTile usage in EnglishDashboardScreen by moving progress content into the `content` parameter

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68963b877a548329b08474ceb01a27ba