### PR TITLE
feat: add session and time analysis schema

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogEntity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogEntity.kt
@@ -11,7 +11,8 @@ import androidx.room.PrimaryKey
     tableName = "attempt_log",
     indices = [
         Index(value = ["qid"], name = "idx_attempt_qid"),
-        Index(value = ["timestamp"], name = "idx_attempt_time")
+        Index(value = ["timestamp"], name = "idx_attempt_time"),
+        Index(value = ["sessionId", "questionIndex"], name = "idx_attempt_session_q")
     ]
 )
 data class AttemptLogEntity(
@@ -26,4 +27,9 @@ data class AttemptLogEntity(
     val sessionId: String? = null,
     val questionIndex: Int = 0,
     val selectedIndex: Int? = null,
+    val startedAt: Long? = null,
+    val answeredAt: Long? = null,
+    val isSkipped: Boolean = false,
+    val isTimeout: Boolean = false,
+    val changeCount: Int = 0,
 )

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/SessionDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/SessionDao.kt
@@ -1,0 +1,36 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SessionDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(session: SessionEntity)
+
+    @Query(
+        """
+        UPDATE sessions
+        SET endedAt = :endedAt,
+            correct = :correct,
+            wrong = :wrong,
+            unattempted = :unattempted,
+            questionCount = :questionCount
+        WHERE sessionId = :sessionId
+        """
+    )
+    suspend fun updateSummary(
+        sessionId: String,
+        endedAt: Long,
+        correct: Int,
+        wrong: Int,
+        unattempted: Int,
+        questionCount: Int
+    )
+
+    @Query("SELECT * FROM sessions ORDER BY startedAt DESC LIMIT :limit")
+    fun latest(limit: Int): Flow<List<SessionEntity>>
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/SessionEntity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/SessionEntity.kt
@@ -1,0 +1,31 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Metadata for a practice or paper solving session.
+ */
+@Entity(
+    tableName = "sessions",
+    indices = [
+        Index(value = ["startedAt"], name = "idx_session_started"),
+        Index(value = ["source", "startedAt"], name = "idx_session_source_started")
+    ]
+)
+data class SessionEntity(
+    @PrimaryKey val sessionId: String,
+    val source: String,
+    val mode: String,
+    val paperId: String? = null,
+    val topicId: String? = null,
+    val subTopic: String? = null,
+    val questionCount: Int = 0,
+    val startedAt: Long,
+    val endedAt: Long? = null,
+    val timeLimitSec: Int? = null,
+    val correct: Int = 0,
+    val wrong: Int = 0,
+    val unattempted: Int = 0
+)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/TimeAnalysisDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/TimeAnalysisDao.kt
@@ -1,0 +1,44 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import androidx.room.Dao
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TimeAnalysisDao {
+    @Query(
+        """
+        SELECT date(startedAt/1000,'unixepoch','localtime') AS day,
+               SUM((answeredAt - startedAt)/60000.0) AS minutes
+        FROM attempt_log
+        WHERE startedAt IS NOT NULL AND answeredAt IS NOT NULL
+        GROUP BY day ORDER BY day DESC LIMIT :days
+        """
+    )
+    fun dailyMinutes(days: Int): Flow<List<DailyMinutesDb>>
+
+    @Query(
+        """
+        SELECT s.sessionId AS sessionId,
+               AVG((a.answeredAt - a.startedAt)/1000.0) AS secPerQ,
+               AVG(CASE WHEN a.correct THEN 1.0 ELSE 0.0 END) AS accuracy
+        FROM sessions s
+        JOIN attempt_log a ON a.sessionId = s.sessionId
+        WHERE a.startedAt IS NOT NULL AND a.answeredAt IS NOT NULL
+        GROUP BY s.sessionId
+        ORDER BY s.startedAt
+        """
+    )
+    fun sessionSpeedAccuracy(): Flow<List<SessionSpeedAccuracyDb>>
+}
+
+data class DailyMinutesDb(
+    val day: String,
+    val minutes: Double
+)
+
+data class SessionSpeedAccuracyDb(
+    val sessionId: String,
+    val secPerQ: Double,
+    val accuracy: Double
+)

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/TimeAnalysisRepository.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/repo/TimeAnalysisRepository.kt
@@ -1,0 +1,19 @@
+package com.concepts_and_quizzes.cds.data.analytics.repo
+
+import com.concepts_and_quizzes.cds.data.analytics.db.SessionDao
+import com.concepts_and_quizzes.cds.data.analytics.db.SessionEntity
+import com.concepts_and_quizzes.cds.data.analytics.db.TimeAnalysisDao
+import javax.inject.Inject
+
+class TimeAnalysisRepository @Inject constructor(
+    private val sessionDao: SessionDao,
+    private val timeDao: TimeAnalysisDao
+) {
+    suspend fun upsertSession(session: SessionEntity) {
+        sessionDao.upsert(session)
+    }
+
+    fun dailyMinutes(days: Int) = timeDao.dailyMinutes(days)
+
+    fun sessionSpeedAccuracy() = timeDao.sessionSpeedAccuracy()
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/db/Migrations.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/db/Migrations.kt
@@ -36,3 +36,36 @@ val MIGRATION_9_10 = object : Migration(9, 10) {
         )
     }
 }
+
+// Migration adding sessions table and extended timing columns.
+val MIGRATION_10_11 = object : Migration(10, 11) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS sessions(
+              sessionId TEXT PRIMARY KEY,
+              source TEXT NOT NULL,
+              mode TEXT NOT NULL,
+              paperId TEXT,
+              topicId TEXT,
+              subTopic TEXT,
+              questionCount INTEGER NOT NULL DEFAULT 0,
+              startedAt INTEGER NOT NULL,
+              endedAt INTEGER,
+              timeLimitSec INTEGER,
+              correct INTEGER NOT NULL DEFAULT 0,
+              wrong INTEGER NOT NULL DEFAULT 0,
+              unattempted INTEGER NOT NULL DEFAULT 0
+            )
+            """.trimIndent()
+        )
+        db.execSQL("ALTER TABLE attempt_log ADD COLUMN startedAt INTEGER")
+        db.execSQL("ALTER TABLE attempt_log ADD COLUMN answeredAt INTEGER")
+        db.execSQL("ALTER TABLE attempt_log ADD COLUMN isSkipped INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("ALTER TABLE attempt_log ADD COLUMN isTimeout INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("ALTER TABLE attempt_log ADD COLUMN changeCount INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("CREATE INDEX IF NOT EXISTS idx_attempt_session_q ON attempt_log(sessionId, questionIndex)")
+        db.execSQL("ALTER TABLE english_questions ADD COLUMN subTopic TEXT NOT NULL DEFAULT ''")
+        db.execSQL("ALTER TABLE english_questions ADD COLUMN difficulty INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabase.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabase.kt
@@ -7,6 +7,9 @@ import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogEntity
 import com.concepts_and_quizzes.cds.data.analytics.db.QuizTrace
 import com.concepts_and_quizzes.cds.data.analytics.db.SessionQuestionMapEntity
 import com.concepts_and_quizzes.cds.data.analytics.db.QuestionStatEntity
+import com.concepts_and_quizzes.cds.data.analytics.db.SessionEntity
+import com.concepts_and_quizzes.cds.data.analytics.db.TimeAnalysisDao
+import com.concepts_and_quizzes.cds.data.analytics.db.SessionDao
 import com.concepts_and_quizzes.cds.data.DateConverters
 import com.concepts_and_quizzes.cds.data.discover.db.ConceptDao
 import com.concepts_and_quizzes.cds.data.discover.model.BookmarkEntity
@@ -27,11 +30,12 @@ import com.concepts_and_quizzes.cds.data.english.model.PyqpQuestionEntity
         QuizTrace::class,
         SessionQuestionMapEntity::class,
         QuestionStatEntity::class,
+        SessionEntity::class,
         ConceptEntity::class,
         DailyTipEntity::class,
         BookmarkEntity::class
     ],
-    version = 10
+    version = 11
 )
 @TypeConverters(DateConverters::class)
 abstract class EnglishDatabase : RoomDatabase() {
@@ -45,4 +49,6 @@ abstract class EnglishDatabase : RoomDatabase() {
     abstract fun sessionQuestionMapDao(): com.concepts_and_quizzes.cds.data.analytics.db.SessionQuestionMapDao
     abstract fun questionStatDao(): com.concepts_and_quizzes.cds.data.analytics.db.QuestionStatDao
     abstract fun conceptDao(): ConceptDao
+    abstract fun sessionDao(): SessionDao
+    abstract fun timeAnalysisDao(): TimeAnalysisDao
 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabaseModule.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/EnglishDatabaseModule.kt
@@ -7,12 +7,16 @@ import com.concepts_and_quizzes.cds.data.english.repo.PyqpRepository
 import com.concepts_and_quizzes.cds.data.analytics.db.AttemptLogDao
 import com.concepts_and_quizzes.cds.data.analytics.db.TopicStatDao
 import com.concepts_and_quizzes.cds.data.analytics.db.QuestionStatDao
+import com.concepts_and_quizzes.cds.data.analytics.db.SessionDao
+import com.concepts_and_quizzes.cds.data.analytics.db.TimeAnalysisDao
 import com.concepts_and_quizzes.cds.data.analytics.repo.AnalyticsRepository
+import com.concepts_and_quizzes.cds.data.analytics.repo.TimeAnalysisRepository
 import com.concepts_and_quizzes.cds.data.analytics.db.QuizTraceDao
 import com.concepts_and_quizzes.cds.data.analytics.repo.QuizReportRepository
 import com.concepts_and_quizzes.cds.data.analytics.db.SessionQuestionMapDao
 import com.concepts_and_quizzes.cds.data.db.MIGRATION_8_9
 import com.concepts_and_quizzes.cds.data.db.MIGRATION_9_10
+import com.concepts_and_quizzes.cds.data.db.MIGRATION_10_11
 import com.concepts_and_quizzes.cds.data.discover.db.ConceptDao
 import dagger.Module
 import dagger.Provides
@@ -28,7 +32,7 @@ object EnglishDatabaseModule {
     @Singleton
     fun provideDatabase(@ApplicationContext ctx: Context): EnglishDatabase =
         Room.databaseBuilder(ctx, EnglishDatabase::class.java, "english.db")
-            .addMigrations(MIGRATION_8_9, MIGRATION_9_10)
+            .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
             .fallbackToDestructiveMigration()
             .build()
 
@@ -63,6 +67,12 @@ object EnglishDatabaseModule {
     fun provideConceptDao(db: EnglishDatabase): ConceptDao = db.conceptDao()
 
     @Provides
+    fun provideSessionDao(db: EnglishDatabase): SessionDao = db.sessionDao()
+
+    @Provides
+    fun provideTimeAnalysisDao(db: EnglishDatabase): TimeAnalysisDao = db.timeAnalysisDao()
+
+    @Provides
     @Singleton
     fun provideEnglishRepository(
         topicDao: EnglishTopicDao,
@@ -84,6 +94,13 @@ object EnglishDatabaseModule {
         questionStatDao: QuestionStatDao
     ): AnalyticsRepository =
         AnalyticsRepository(attemptDao, topicStatDao, questionStatDao)
+
+    @Provides
+    @Singleton
+    fun provideTimeAnalysisRepository(
+        sessionDao: SessionDao,
+        timeAnalysisDao: TimeAnalysisDao
+    ): TimeAnalysisRepository = TimeAnalysisRepository(sessionDao, timeAnalysisDao)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/SeedUtil.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/db/SeedUtil.kt
@@ -48,7 +48,9 @@ class SeedUtil @Inject constructor(
                             optionB = q.getString("optionB"),
                             optionC = q.getString("optionC"),
                             optionD = q.getString("optionD"),
-                            correct = q.getString("correct")
+                            correct = q.getString("correct"),
+                            subTopic = q.optString("subTopic", ""),
+                            difficulty = q.optInt("difficulty", 0)
                         )
                     )
                 }

--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/EnglishQuestionEntity.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/english/model/EnglishQuestionEntity.kt
@@ -13,7 +13,9 @@ data class EnglishQuestionEntity(
     val optionB: String,
     val optionC: String,
     val optionD: String,
-    val correct: String
+    val correct: String,
+    val subTopic: String = "",
+    val difficulty: Int = 0
 )
 
 fun EnglishQuestionEntity.toDomain() = EnglishQuestion(
@@ -24,5 +26,7 @@ fun EnglishQuestionEntity.toDomain() = EnglishQuestion(
     optionB,
     optionC,
     optionD,
-    correct
+    correct,
+    subTopic,
+    difficulty
 )

--- a/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/EnglishQuestion.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/domain/english/EnglishQuestion.kt
@@ -8,5 +8,7 @@ data class EnglishQuestion(
     val optionB: String,
     val optionC: String,
     val optionD: String,
-    val correct: String
+    val correct: String,
+    val subTopic: String = "",
+    val difficulty: Int = 0
 )


### PR DESCRIPTION
## Summary
- add Room entity and DAO for sessions
- expand attempt logging with start/end timestamps, skip/timeout flags, and change counts
- track subTopic and difficulty for English questions
- expose time-analysis queries via TimeAnalysisDao and repository

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68963cef5f2483299a7fb7b72efdec9d