### PR TITLE
Hook Trend page Start Practice to quiz navigation

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/core/navigation/NavGraph.kt
@@ -115,7 +115,10 @@ fun NavGraphBuilder.rootGraph(nav: NavHostController) {
         )
     ) { backStack ->
         val sid = backStack.arguments?.getString("analysisSessionId")
-        ReportsPagerScreen(navArgs = ReportsNavArgs(sid))
+        ReportsPagerScreen(
+            navArgs = ReportsNavArgs(sid),
+            onStartPractice = { nav.navigate("english/pyqp") },
+        )
     }
     composable(
         route = "english/pyqp/{paperId}",

--- a/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/ui/reports/ReportsScreen.kt
@@ -38,8 +38,14 @@ import com.concepts_and_quizzes.cds.ui.reports.trend.TrendPage
 /* ---- keep existing navigation API ---- */
 
 @Composable
-fun ReportsPagerScreen(navArgs: ReportsNavArgs) {
-    ReportsScreen(analysisSessionId = navArgs.analysisSessionId)
+fun ReportsPagerScreen(
+    navArgs: ReportsNavArgs = ReportsNavArgs(),
+    onStartPractice: (() -> Unit)? = null,
+) {
+    ReportsScreen(
+        analysisSessionId = navArgs.analysisSessionId,
+        onStartPractice = onStartPractice,
+    )
 }
 
 
@@ -48,7 +54,8 @@ fun ReportsPagerScreen(navArgs: ReportsNavArgs) {
 fun ReportsScreen(
     onShare: () -> Unit = {},
     startPage: Int = 0,
-    analysisSessionId: String? = null
+    analysisSessionId: String? = null,
+    onStartPractice: (() -> Unit)? = null,
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
@@ -126,7 +133,7 @@ fun ReportsScreen(
             ) {
                 when (selectedTab) {
                     0 -> LastQuizPage(sessionId = analysisSessionId)
-                    1 -> TrendPage(window = windowArg)        // replace with TrendPage(window = windowArg)
+                    1 -> TrendPage(window = windowArg, onStartPractice = onStartPractice)
                     2 -> HeatmapPage(window = windowArg)
                     3 -> TimePage(window = windowArg)
                     4 -> PlaceholderTab("Peer")          // replace with PeerPage(window = windowArg)


### PR DESCRIPTION
## Summary
- Pass an optional `onStartPractice` callback through `ReportsPagerScreen` and `ReportsScreen`
- Wire Trend tab to invoke the callback so the Start Practice button can launch a quiz
- Navigate to `english/pyqp` when Start Practice is triggered from Reports route

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689781b7b5748329a12c1daa69ba0e29