### PR TITLE
Fix trend grouping to use local timezone

### DIFF
--- a/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
+++ b/app/src/main/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDao.kt
@@ -24,7 +24,7 @@ interface AttemptLogDao {
     @Query(
         """
         SELECT q.topicId AS topicId,
-               strftime('%Y-%m-%d', a.timestamp/1000, 'unixepoch') AS day,
+               strftime('%Y-%m-%d', a.timestamp/1000, 'unixepoch', 'localtime') AS day,
                COUNT(*) AS total,
                SUM(CASE WHEN a.correct THEN 1 ELSE 0 END) AS correct
         FROM attempt_log a

--- a/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDaoTest.kt
+++ b/app/src/test/java/com/concepts_and_quizzes/cds/data/analytics/db/AttemptLogDaoTest.kt
@@ -1,0 +1,85 @@
+package com.concepts_and_quizzes.cds.data.analytics.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.concepts_and_quizzes.cds.data.english.db.EnglishDatabase
+import com.concepts_and_quizzes.cds.data.english.model.EnglishQuestionEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.TimeZone
+
+@RunWith(RobolectricTestRunner::class)
+class AttemptLogDaoTest {
+
+    private lateinit var db: EnglishDatabase
+    private lateinit var dao: AttemptLogDao
+
+    @Before
+    fun setUp() {
+        // Use a timezone with a non-zero offset to surface UTC/local mismatches
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Kolkata"))
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, EnglishDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.attemptLogDao()
+
+        // Insert a question required for join in getTrend()
+        runBlocking {
+            db.questionDao().insertAll(
+                listOf(
+                    EnglishQuestionEntity(
+                        qid = "Q1",
+                        topicId = "T1",
+                        question = "q",
+                        optionA = "a",
+                        optionB = "b",
+                        optionC = "c",
+                        optionD = "d",
+                        correct = "A"
+                    )
+                )
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun getTrend_usesLocalDate() = runTest {
+        val ts = LocalDate.of(2025, 1, 1)
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+        dao.insertAll(
+            listOf(
+                AttemptLogEntity(
+                    qid = "Q1",
+                    quizId = "quiz",
+                    correct = true,
+                    flagged = false,
+                    durationMs = 0,
+                    timestamp = ts
+                )
+            )
+        )
+
+        val trend = dao.getTrend(0L).first()
+        assertEquals(1, trend.size)
+        assertEquals("2025-01-01", trend.first().day)
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure trend query groups by local date instead of UTC
- add test verifying trend uses device timezone

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897851851e88329bf5462833a43b475